### PR TITLE
fix(#194): 여행 날짜 선택 시 과거 날짜 비활성화 및 회색 처리

### DIFF
--- a/apps/mohang-app/src/app/pages/CalendarPage/CalendarGrid.tsx
+++ b/apps/mohang-app/src/app/pages/CalendarPage/CalendarGrid.tsx
@@ -19,6 +19,7 @@ interface CalendarGridProps {
     month: number;
     day: number;
   }) => Country | undefined;
+  isPastDate: (date: Date) => boolean;
   onPrevMonth: () => void;
   onNextMonth: () => void;
 }
@@ -31,6 +32,7 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
   onDateClick,
   isSelected,
   getConfirmedCountry,
+  isPastDate,
   onPrevMonth,
   onNextMonth,
 }) => {
@@ -108,6 +110,9 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
             ).getTime() === currentTimestamp;
 
           const isCurrentMonth = dateObj.type === 'current';
+          const isPast = isPastDate(
+            new Date(dateObj.year, dateObj.month, dateObj.day),
+          );
 
           const cellStyle: React.CSSProperties = {
             backgroundColor:
@@ -120,8 +125,9 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
                     : confirmedCountry
                       ? colors.gray[200]
                       : undefined,
-            color:
-              isStart || isEnd || confirmedCountry
+            color: isPast
+              ? colors.gray[200]
+              : isStart || isEnd || confirmedCountry
                 ? colors.white.white100
                 : !isCurrentMonth
                   ? colors.gray[300]
@@ -129,13 +135,14 @@ export const CalendarGrid: React.FC<CalendarGridProps> = ({
                     ? colors.primary[700]
                     : colors.gray[400],
             fontWeight: isStart || isEnd ? 700 : active ? 500 : undefined,
+            cursor: isPast ? 'not-allowed' : 'pointer',
           };
 
           return (
             <div
               key={i}
-              onClick={() => onDateClick(dateObj)}
-              className={`relative py-5 flex items-center justify-center cursor-pointer text-sm transition-all rounded-md ${!active ? 'hover:bg-gray-100' : ''} ${isStart || isEnd ? 'pt-1' : ''}`}
+              onClick={() => !isPast && onDateClick(dateObj)}
+              className={`relative py-5 flex items-center justify-center text-sm transition-all rounded-md ${!active && !isPast ? 'hover:bg-gray-100' : ''} ${isStart || isEnd ? 'pt-1' : ''}`}
               style={{ ...cellStyle, ...typography.body.LBodyB }}
             >
               <span className={isStart || isEnd ? 'font-bold' : ''}>

--- a/apps/mohang-app/src/app/pages/CalendarPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/CalendarPage/index.tsx
@@ -45,6 +45,7 @@ export default function CalendarPage() {
     getConfirmedCountry,
     handleCountryChange,
     setCurrentDate,
+    isPastDate,
   } = useCalendarLogic(mappedCountries);
 
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -75,6 +76,7 @@ export default function CalendarPage() {
             onDateClick={handleDateClick}
             isSelected={isSelected}
             getConfirmedCountry={getConfirmedCountry}
+            isPastDate={isPastDate}
             onPrevMonth={() => setCurrentDate(new Date(year, month - 1, 1))}
             onNextMonth={() => setCurrentDate(new Date(year, month + 1, 1))}
           />

--- a/apps/mohang-app/src/app/pages/CalendarPage/useCalendarLogic.ts
+++ b/apps/mohang-app/src/app/pages/CalendarPage/useCalendarLogic.ts
@@ -136,16 +136,24 @@ export const useCalendarLogic = (initialCountries: Country[]) => {
     });
   }
 
-  const handleDateClick = (calendarDay: CalendarDay) => {
-    if (calendarDay.type === 'prev' || calendarDay.type === 'next') {
-      setCurrentDate(new Date(calendarDay.year, calendarDay.month, 1));
-    }
+  const isPastDate = (date: Date) => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return date < today;
+  };
 
+  const handleDateClick = (calendarDay: CalendarDay) => {
     const clickedDate = new Date(
       calendarDay.year,
       calendarDay.month,
       calendarDay.day,
     );
+
+    if (isPastDate(clickedDate)) return;
+
+    if (calendarDay.type === 'prev' || calendarDay.type === 'next') {
+      setCurrentDate(new Date(calendarDay.year, calendarDay.month, 1));
+    }
 
     if (!range.start || (range.start && range.end)) {
       setRange({ start: clickedDate, end: null });
@@ -244,5 +252,6 @@ export const useCalendarLogic = (initialCountries: Country[]) => {
     isSelected,
     getConfirmedCountry,
     handleCountryChange,
+    isPastDate,
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 캘린더에서 과거 날짜 선택이 불가능하도록 변경했습니다. 과거 날짜는 회색으로 표시되고 마우스 커서가 금지 표시로 변경되며, 클릭 시 아무런 작동이 일어나지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->