### PR TITLE
fix: prevent companion selection for solo roadmap creation

### DIFF
--- a/apps/mohang-app/src/app/pages/CompanionPage.tsx
+++ b/apps/mohang-app/src/app/pages/CompanionPage.tsx
@@ -6,7 +6,7 @@ import {
   colors,
   typography,
 } from '@mohang/ui';
-import { Link } from 'react-router-dom';
+import { Link, Navigate } from 'react-router-dom';
 import solo from '../../assets/images/solo.png';
 import parents from '../../assets/images/parents.png';
 import friends from '../../assets/images/friends.png';
@@ -37,6 +37,7 @@ const companionMap: Record<string, string> = {
 
 export default function CompanionPage() {
   const { surveyData, updateSurveyData } = useSurvey();
+  const peopleCount = Number(surveyData.people_count);
   const selectedCompanions = surveyData.companion_type || [];
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -52,6 +53,16 @@ export default function CompanionPage() {
     const token = getAccessToken();
     setIsLoggedIn(!!token && token !== 'undefined');
   }, []);
+
+  useEffect(() => {
+    if (peopleCount === 1 && selectedCompanions.length > 0) {
+      updateSurveyData({ companion_type: [] });
+    }
+  }, [peopleCount, selectedCompanions.length, updateSurveyData]);
+
+  if (peopleCount === 1) {
+    return <Navigate to="/travel-concept" replace />;
+  }
 
   return (
     <div className="min-h-screen bg-white flex flex-col">

--- a/apps/mohang-app/src/app/pages/PeopleCountPage.tsx
+++ b/apps/mohang-app/src/app/pages/PeopleCountPage.tsx
@@ -20,7 +20,11 @@ export default function PeopleCountPage() {
 
   const handleDecrease = () => {
     if (count > 1) {
-      updateSurveyData({ people_count: count - 1 });
+      const nextCount = count - 1;
+      updateSurveyData({
+        people_count: nextCount,
+        companion_type: nextCount === 1 ? [] : surveyData.companion_type,
+      });
     }
   };
 
@@ -121,7 +125,7 @@ export default function PeopleCountPage() {
           이전
         </Link>
         <Link
-          to="/companion"
+          to={count === 1 ? '/travel-concept' : '/companion'}
           className="px-8 py-2 rounded-lg text-white text-base transition-all active:scale-95 pointer-events-auto shadow-sm"
           style={{
             backgroundColor: colors.primary[500],

--- a/apps/mohang-app/src/app/pages/TravelConceptPage.tsx
+++ b/apps/mohang-app/src/app/pages/TravelConceptPage.tsx
@@ -52,6 +52,7 @@ const conceptMap: Record<string, string> = {
 
 export default function TravelConceptPage() {
   const { surveyData, updateSurveyData } = useSurvey();
+  const peopleCount = Number(surveyData.people_count);
   const selectedThemes = surveyData.travel_themes || [];
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -121,7 +122,7 @@ export default function TravelConceptPage() {
 
       <footer className="fixed bottom-10 left-0 w-full px-12 flex justify-between pointer-events-none">
         <Link
-          to="/companion"
+          to={peopleCount === 1 ? '/people-count' : '/companion'}
           className="px-6 py-2 rounded-lg text-white text-base transition-all active:scale-95 pointer-events-auto bg-gray-400 hover:bg-gray-500 shadow-sm"
           style={{
             ...typography.body.BodyM,


### PR DESCRIPTION
## Summary
- skip the companion step when people count is 1
- clear selected companion types when the count changes back to 1
- redirect direct access to the companion page for solo trips

## Testing
- not run (local shell could not resolve node/tsc in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* 여행인원 수에 따른 동적 페이지 흐름이 추가되었습니다.

## 버그 수정
* 여행인원이 1명으로 설정되었을 때 동반자 선택 페이지를 건너뛰고 여행컨셉 선택 페이지로 직접 이동합니다.
* 여행인원을 수정할 때 선택된 동반자 정보가 자동으로 초기화됩니다.
* 여행인원 수에 따라 페이지 간 이전/다음 네비게이션이 올바르게 작동하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->