### PR TITLE
fix: 나라 사진 로딩 실패 시 pexels 폴백 이미지 적용

### DIFF
--- a/apps/mohang-app/src/app/pages/HomePage.tsx
+++ b/apps/mohang-app/src/app/pages/HomePage.tsx
@@ -42,7 +42,7 @@ interface RecommendedDestinationCard {
 }
 
 const FALLBACK_REGION_IMAGE =
-  'https://images.unsplash.com/photo-1488085061387-422e29b40080?w=800';
+  'https://images.pexels.com/photos/9782676/pexels-photo-9782676.jpeg';
 
 const COUNTRY_COORDINATES: Record<string, { lat: number; lon: number }> = {
   'south korea': { lat: 36.5, lon: 127.8 },
@@ -230,7 +230,7 @@ export function HomePage({ initialUser }: HomePageProps) {
       : '일정 정보 없음',
     description: c.description || `${c.title}와(과) 함께하는 여행`,
     tags: c.tags || [],
-    imageUrl: c.imageUrl || 'https://images.unsplash.com/photo-1488085061387-422e29b40080?w=800',
+    imageUrl: c.imageUrl || 'https://images.pexels.com/photos/9782676/pexels-photo-9782676.jpeg',
     isLiked: c.is_liked ?? c.isLiked,
     is_liked: c.is_liked ?? c.isLiked,
     likeCount: c.like_count ?? c.likeCount,
@@ -263,7 +263,7 @@ export function HomePage({ initialUser }: HomePageProps) {
     imageUrl:
       blog.imageUrl ||
       blog.imageUrls?.[0] ||
-      'https://images.unsplash.com/photo-1488085061387-422e29b40080?w=800',
+      'https://images.pexels.com/photos/9782676/pexels-photo-9782676.jpeg',
     likes: Number(blog.likeCount ?? 0),
     isLiked: Boolean(blog.isLiked),
   }));

--- a/apps/mohang-app/src/app/pages/TravelSelectionPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/TravelSelectionPage/index.tsx
@@ -38,7 +38,7 @@ interface SliderCountry {
 }
 
 const FALLBACK_COUNTRY_IMAGE =
-  'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1200';
+  'https://images.pexels.com/photos/9782676/pexels-photo-9782676.jpeg';
 
 const preloadImage = (src?: string | null) =>
   new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- 나라/지역 이미지 로딩 실패 시 기존 Unsplash 폴백 URL을 pexels 이미지로 교체

## Changes
- `TravelSelectionPage/index.tsx` — `FALLBACK_COUNTRY_IMAGE` 교체
- `HomePage.tsx` — `FALLBACK_REGION_IMAGE` 상수 및 인라인 폴백 2곳 교체

## Test plan
- [ ] 나라 이미지 URL이 없는 경우 pexels 이미지가 표시되는지 확인
- [ ] TravelSelectionPage 슬라이더 폴백 이미지 확인
- [ ] HomePage 추천 지역, 방문 국가, 블로그 카드 폴백 이미지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기타**
  * 앱 전체의 기본 대체 이미지를 업데이트했습니다. 추천 목적지 카드, 코스, 블로그 피드에서 사용되는 기본 이미지가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->