### PR TITLE
feat(#278): 채팅 내역 조회 및 로드맵 재진입 시 채팅 상태 유지 기능 구현

### DIFF
--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -10,6 +10,7 @@ import {
   Header,
   getItineraryStatus,
   getItineraryResult,
+  getItineraryChatHistory,
   chatItineraryEdit,
   chatItineraryEditStatus,
   getAccessToken,
@@ -24,6 +25,7 @@ import {
 
 const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 const defaultCenter = { lat: 16.4855, lng: 97.6216 };
+const defaultAiMessage = '?덈뀞?섏꽭?? ?대뼡 ?쇱젙 ?섏젙???꾩??쒕┫源뚯슂?';
 
 interface Message {
   id: string;
@@ -32,6 +34,43 @@ interface Message {
   timestamp: Date;
   isPending?: boolean;
 }
+
+const getDefaultMessages = (): Message[] => [
+  {
+    id: '1',
+    sender: 'ai',
+    text: defaultAiMessage,
+    timestamp: new Date(),
+  },
+];
+
+const normalizeChatMessage = (message: any, index: number): Message | null => {
+  const senderValue = String(message?.sender || message?.role || '').toUpperCase();
+  const sender =
+    senderValue === 'USER'
+      ? 'user'
+      : senderValue === 'ASSISTANT' || senderValue === 'AI'
+        ? 'ai'
+        : null;
+  const text = message?.text || message?.message || message?.content;
+
+  if (!sender || !text) {
+    return null;
+  }
+
+  const timestampValue =
+    message?.timestamp || message?.createdAt || message?.created_at;
+  const parsedTimestamp = timestampValue ? new Date(timestampValue) : new Date();
+
+  return {
+    id: String(message?.id ?? `history-${index}`),
+    sender,
+    text,
+    timestamp: Number.isNaN(parsedTimestamp.getTime())
+      ? new Date()
+      : parsedTimestamp,
+  };
+};
 
 const resolveIsMyPlan = ({
   data,
@@ -102,6 +141,7 @@ const PlanDetailPage = () => {
       timestamp: new Date(),
     },
   ]);
+  const [hasChatHistory, setHasChatHistory] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [currentUser, setCurrentUser] = useState<UserResponse | null>(null);
 
@@ -345,6 +385,49 @@ const PlanDetailPage = () => {
     return () => clearInterval(pollInterval);
   }, [jobId]);
 
+  useEffect(() => {
+    if (!travelCourseId) {
+      setHasChatHistory(false);
+      return;
+    }
+
+    let isCancelled = false;
+
+    const fetchChatHistory = async () => {
+      try {
+        const history = await getItineraryChatHistory(travelCourseId);
+        if (isCancelled) return;
+
+        const normalizedMessages = history
+          .map((message: any, index: number) => normalizeChatMessage(message, index))
+          .filter(Boolean) as Message[];
+
+        setHasChatHistory(normalizedMessages.length > 0);
+
+        if (normalizedMessages.length > 0) {
+          setMessages(normalizedMessages);
+        } else {
+          setMessages(getDefaultMessages());
+        }
+      } catch (error: any) {
+        if (isCancelled) return;
+
+        if (error?.statusCode !== 404) {
+          console.error('Failed to fetch chat history:', error);
+        }
+
+        setHasChatHistory(false);
+        setMessages(getDefaultMessages());
+      }
+    };
+
+    fetchChatHistory();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [travelCourseId]);
+
   const handleSendMessage = async (customMessage?: string) => {
     const textToSend = customMessage || inputValue;
     if (!textToSend.trim()) return;
@@ -361,6 +444,7 @@ const PlanDetailPage = () => {
     };
 
     setMessages((prev) => [...prev, userMessage]);
+    setHasChatHistory(true);
     const originalInput = textToSend;
     if (!customMessage) setInputValue('');
     setIsChatSidebarOpen(true);
@@ -607,6 +691,17 @@ const PlanDetailPage = () => {
               isScheduleSidebarOpen ? '-translate-x-2/3' : '-translate-x-1/2'
             }`}
           >
+            {hasChatHistory && (
+              <div className="mb-3 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => setIsChatSidebarOpen(true)}
+                  className="rounded-full bg-white/95 px-4 py-2 text-xs font-bold text-sky-600 shadow-lg transition hover:bg-white"
+                >
+                  채팅 내역 보기
+                </button>
+              </div>
+            )}
             <div className="relative">
               <textarea
                 value={inputValue}

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -25,7 +25,7 @@ import {
 
 const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 const defaultCenter = { lat: 16.4855, lng: 97.6216 };
-const defaultAiMessage = '?덈뀞?섏꽭?? ?대뼡 ?쇱젙 ?섏젙???꾩??쒕┫源뚯슂?';
+const defaultAiMessage = '안녕하세요! 어떤 일정 수정을 도와드릴까요?';
 
 interface Message {
   id: string;

--- a/libs/ui/src/api/Itineraries.ts
+++ b/libs/ui/src/api/Itineraries.ts
@@ -98,6 +98,57 @@ export interface ChatEditResponse {
   message: string;
 }
 
+export interface ItineraryChatHistoryMessage {
+  id?: string | number;
+  role?: 'USER' | 'ASSISTANT' | 'SYSTEM' | 'user' | 'assistant' | 'ai';
+  sender?: 'user' | 'assistant' | 'ai';
+  content?: string;
+  message?: string;
+  text?: string;
+  createdAt?: string;
+  created_at?: string;
+  timestamp?: string;
+}
+
+export const getItineraryChatHistory = async (
+  travelCourseId: string | null,
+): Promise<ItineraryChatHistoryMessage[]> => {
+  if (!travelCourseId) {
+    return [];
+  }
+
+  try {
+    const response = await privateApi.get(
+      `/api/v1/itineraries/${travelCourseId}/chats`,
+      {
+        headers: getAuthHeaders(),
+      },
+    );
+
+    const payload = response.data?.data || response.data;
+
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (Array.isArray(payload?.chats)) {
+      return payload.chats;
+    }
+
+    if (Array.isArray(payload?.messages)) {
+      return payload.messages;
+    }
+
+    if (Array.isArray(payload?.history)) {
+      return payload.history;
+    }
+
+    return [];
+  } catch (error: any) {
+    throw handleApiError(error, '채팅 내역 조회에 실패했습니다.');
+  }
+};
+
 const getAuthHeaders = () => {
   if (typeof window === 'undefined') return {};
   const token = getAccessToken();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 여행 계획 페이지에서 과거 채팅 내역을 조회·정리해 표시
  * 기록이 없을 경우 기본 AI 안내 메시지로 안전하게 대체
  * 다양한 형식의 채팅 데이터를 통일하여 유효하지 않은 항목은 제외
  * 사용자가 메시지 전송 시 즉시 기록이 있는 상태로 반영
  * 채팅 입력 오버레이가 닫힌 상태에서 "채팅 내역 보기" 버튼으로 채팅 창 재열기 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->