### PR TITLE
[FE] 여행 블로그 전체 목록 페이지 구현

### DIFF
--- a/apps/mohang-app/src/app/app.tsx
+++ b/apps/mohang-app/src/app/app.tsx
@@ -21,6 +21,7 @@ import LandingPage from './pages/LandingPage';
 import FeedbackPage from './pages/FeedbackPage';
 import BlogWritePage from './pages/BlogWritePage';
 import BlogDetailPage from './pages/BlogDetailPage';
+import BlogListPage from './pages/BlogListPage';
 import AuthGuard from './components/AuthGuard';
 import { AlertProvider } from './context/AlertContext';
 
@@ -156,6 +157,14 @@ export function App() {
           element={
             <AuthGuard>
               <FeedbackPage />
+            </AuthGuard>
+          }
+        />
+        <Route
+          path="/blogs"
+          element={
+            <AuthGuard>
+              <BlogListPage />
             </AuthGuard>
           }
         />

--- a/apps/mohang-app/src/app/pages/BlogListPage.tsx
+++ b/apps/mohang-app/src/app/pages/BlogListPage.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  colors,
+  FeedGrid,
+  getAccessToken,
+  getMainBlogs,
+  Header,
+  type GridFeedItem,
+  typography,
+} from '@mohang/ui';
+
+const PAGE_SIZE = 12;
+const FALLBACK_BLOG_IMAGE =
+  'https://images.pexels.com/photos/9782676/pexels-photo-9782676.jpeg';
+
+const getSafeSort = (value: string | null): 'latest' | 'popular' =>
+  value === 'popular' ? 'popular' : 'latest';
+
+const getSafePage = (value: string | null) => {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return 1;
+  }
+
+  return parsed;
+};
+
+const createPageRange = (currentPage: number, totalPages: number) => {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const start = Math.max(1, Math.min(currentPage - 2, totalPages - 4));
+  return Array.from({ length: 5 }, (_, index) => start + index);
+};
+
+export function BlogListPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const isLoggedIn = Boolean(getAccessToken());
+
+  const sortBy = getSafeSort(searchParams.get('sortBy'));
+  const currentPage = getSafePage(searchParams.get('page'));
+
+  useEffect(() => {
+    const currentSort = searchParams.get('sortBy');
+    const currentPageParam = searchParams.get('page');
+
+    if (currentSort === sortBy && currentPageParam === String(currentPage)) {
+      return;
+    }
+
+    setSearchParams(
+      {
+        sortBy,
+        page: String(currentPage),
+      },
+      { replace: true },
+    );
+  }, [currentPage, searchParams, setSearchParams, sortBy]);
+
+  const blogsQuery = useQuery({
+    queryKey: ['blog-list-page', sortBy, currentPage],
+    queryFn: () =>
+      getMainBlogs({
+        sortBy,
+        page: currentPage,
+        limit: PAGE_SIZE,
+      }),
+  });
+
+  const blogItems = useMemo(() => {
+    const data = blogsQuery.data as any;
+
+    return Array.isArray(data)
+      ? data
+      : data?.data?.blogs || data?.blogs || data?.data?.items || data?.items || [];
+  }, [blogsQuery.data]);
+
+  const feeds = useMemo<GridFeedItem[]>(
+    () =>
+      blogItems.map((blog: any) => ({
+        id: blog.id,
+        author: blog.userName || '',
+        date: blog.createdAt?.split('T')?.[0] || '',
+        title: blog.title || '',
+        content: blog.content || '',
+        imageUrl:
+          blog.imageUrl || blog.imageUrls?.[0] || FALLBACK_BLOG_IMAGE,
+        likes: Number(blog.likeCount ?? 0),
+        isLiked: Boolean(blog.isLiked),
+      })),
+    [blogItems],
+  );
+
+  const totalPages = Math.max(
+    1,
+    Number((blogsQuery.data as any)?.totalPages ?? 1),
+  );
+  const visiblePages = createPageRange(currentPage, totalPages);
+
+  useEffect(() => {
+    if (currentPage <= totalPages) return;
+
+    setSearchParams(
+      {
+        sortBy,
+        page: String(totalPages),
+      },
+      { replace: true },
+    );
+  }, [currentPage, setSearchParams, sortBy, totalPages]);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [currentPage, sortBy]);
+
+  const updateParams = (next: {
+    page?: number;
+    sortBy?: 'latest' | 'popular';
+  }) => {
+    setSearchParams({
+      sortBy: next.sortBy ?? sortBy,
+      page: String(next.page ?? currentPage),
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-cyan-50/50 via-white to-white">
+      <Header isLoggedIn={isLoggedIn} />
+
+      <main className="mx-auto max-w-7xl px-4 py-8 md:px-8 md:py-12">
+        <section className="mb-8">
+          <div className="flex flex-wrap gap-3">
+            {[
+              { key: 'latest', label: '최신순' },
+              { key: 'popular', label: '인기순' },
+            ].map((option) => (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() =>
+                  updateParams({
+                    sortBy: option.key as 'latest' | 'popular',
+                    page: 1,
+                  })
+                }
+                className={`rounded-full px-5 py-2.5 text-sm font-bold transition-all ${
+                  sortBy === option.key
+                    ? 'bg-[#00CCFF] text-white'
+                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {blogsQuery.isLoading ? (
+          <section className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, index) => (
+              <div
+                key={index}
+                className="overflow-hidden rounded-[24px] border border-gray-100 bg-white p-4 shadow-sm"
+              >
+                <div className="aspect-[4/3] animate-pulse rounded-[20px] bg-gray-100" />
+                <div className="mt-6 h-4 w-28 animate-pulse rounded-full bg-gray-100" />
+                <div className="mt-4 h-6 w-4/5 animate-pulse rounded-full bg-gray-100" />
+                <div className="mt-3 h-4 w-full animate-pulse rounded-full bg-gray-100" />
+                <div className="mt-2 h-4 w-2/3 animate-pulse rounded-full bg-gray-100" />
+              </div>
+            ))}
+          </section>
+        ) : blogsQuery.isError ? (
+          <section className="rounded-[28px] border border-red-100 bg-white px-6 py-16 text-center shadow-sm">
+            <p
+              style={{
+                ...typography.title.sTitleB,
+                color: colors.gray[800],
+              }}
+            >
+              블로그 목록을 불러오지 못했습니다.
+            </p>
+            <p
+              className="mt-3"
+              style={{
+                ...typography.body.BodyM,
+                color: colors.gray[400],
+              }}
+            >
+              잠시 후 다시 시도해주세요.
+            </p>
+            <button
+              type="button"
+              onClick={() => blogsQuery.refetch()}
+              className="mt-6 rounded-full bg-[#00CCFF] px-6 py-3 font-bold text-white transition-colors hover:bg-[#00B6E4]"
+            >
+              다시 불러오기
+            </button>
+          </section>
+        ) : feeds.length > 0 ? (
+          <>
+            <FeedGrid
+              feeds={feeds}
+              showMoreButton={false}
+              desktopColumns={4}
+              compact
+            />
+
+            <div className="mt-12 flex flex-col items-center gap-4">
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => updateParams({ page: currentPage - 1 })}
+                  disabled={currentPage <= 1}
+                  className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-500 transition-colors hover:border-cyan-200 hover:text-cyan-600 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  이전
+                </button>
+
+                {visiblePages.map((pageNumber) => (
+                  <button
+                    key={pageNumber}
+                    type="button"
+                    onClick={() => updateParams({ page: pageNumber })}
+                    className={`h-11 min-w-[44px] rounded-full px-4 text-sm font-bold transition-all ${
+                      currentPage === pageNumber
+                        ? 'bg-[#00CCFF] text-white shadow-[0_10px_24px_rgba(0,204,255,0.2)]'
+                        : 'border border-gray-200 bg-white text-gray-500 hover:border-cyan-200 hover:text-cyan-600'
+                    }`}
+                  >
+                    {pageNumber}
+                  </button>
+                ))}
+
+                <button
+                  type="button"
+                  onClick={() => updateParams({ page: currentPage + 1 })}
+                  disabled={currentPage >= totalPages}
+                  className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-500 transition-colors hover:border-cyan-200 hover:text-cyan-600 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  다음
+                </button>
+              </div>
+
+              <p
+                style={{
+                  ...typography.label.labelM,
+                  color: colors.gray[400],
+                }}
+              >
+                {currentPage} / {totalPages} 페이지
+              </p>
+            </div>
+          </>
+        ) : (
+          <section className="rounded-[28px] border border-gray-100 bg-white px-6 py-16 text-center shadow-sm">
+            <p
+              style={{
+                ...typography.title.sTitleB,
+                color: colors.gray[800],
+              }}
+            >
+              아직 공개된 블로그가 없습니다.
+            </p>
+            <p
+              className="mt-3"
+              style={{
+                ...typography.body.BodyM,
+                color: colors.gray[400],
+              }}
+            >
+              첫 번째 여행 기록이 등록되면 이곳에서 바로 확인할 수 있습니다.
+            </p>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+
+export default BlogListPage;

--- a/apps/mohang-app/src/app/pages/HomePage.tsx
+++ b/apps/mohang-app/src/app/pages/HomePage.tsx
@@ -334,6 +334,10 @@ export function HomePage({ initialUser }: HomePageProps) {
     setCurrentPage(1);
   };
 
+  const handleBlogMoreClick = () => {
+    navigate(`/blogs?sortBy=${blogSortBy}&page=1`);
+  };
+
   const handleActiveIdChange = (id: string) => {
     // No-op or update local display if needed
   };
@@ -511,7 +515,23 @@ export function HomePage({ initialUser }: HomePageProps) {
                 블로그 목록을 불러오는 중입니다...
               </div>
             ) : (
-              <FeedGrid feeds={feeds} />
+              <>
+                <FeedGrid feeds={feeds} showMoreButton={false} />
+                {feeds.length > 0 ? (
+                  <div className="mt-10 flex justify-center">
+                    <button
+                      type="button"
+                      onClick={handleBlogMoreClick}
+                      className="rounded-full border-2 border-[#00c7f2] px-7 py-2.5 text-[#00c7f2] transition-all hover:bg-[#00c7f2] hover:text-white"
+                      style={{
+                        ...typography.body.BodyM,
+                      }}
+                    >
+                      더보러가기
+                    </button>
+                  </div>
+                ) : null}
+              </>
             )}
           </section>
         </div>

--- a/libs/ui/src/lib/FeedGrid.tsx
+++ b/libs/ui/src/lib/FeedGrid.tsx
@@ -20,9 +20,18 @@ export interface FeedItem {
 export interface FeedGridProps {
   feeds: FeedItem[];
   onFeedLikeChange?: () => void | Promise<void>;
+  showMoreButton?: boolean;
+  desktopColumns?: 3 | 4;
+  compact?: boolean;
 }
 
-export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
+export function FeedGrid({
+  feeds,
+  onFeedLikeChange,
+  showMoreButton = true,
+  desktopColumns = 3,
+  compact = false,
+}: FeedGridProps) {
   const navigate = useNavigate();
   const { likeCounts, hearts, handleHeartClick } = useLikeCounts({ feeds });
   const [showComingSoon, setShowComingSoon] = useState(false);
@@ -39,7 +48,13 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
 
   return (
     <>
-      <div className="grid max-w-7xl grid-cols-1 gap-x-6 gap-y-10 mx-auto md:grid-cols-2 lg:grid-cols-3">
+      <div
+        className={`grid max-w-7xl grid-cols-1 mx-auto md:grid-cols-2 ${
+          compact ? 'gap-x-5 gap-y-8' : 'gap-x-6 gap-y-10'
+        } ${
+          desktopColumns === 4 ? 'xl:grid-cols-4 lg:grid-cols-4' : 'lg:grid-cols-3'
+        }`}
+      >
         {feeds.length === 0 ? (
           <div className="col-span-full flex items-center justify-center py-20 text-gray-400">
             ?쒖떆???ы뻾 湲곕줉???놁뒿?덈떎
@@ -51,36 +66,27 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
               className="group cursor-pointer"
               onClick={() => navigate(`/blog/${feed.id}`)}
             >
-              <div className="relative mb-4">
-                <div className="aspect-[4/3] overflow-hidden rounded-[24px] bg-gray-100 shadow-sm transition-transform duration-300 group-hover:-translate-y-1">
+              <div className={compact ? 'mb-3' : 'mb-4'}>
+                <div
+                  className={`aspect-[4/3] overflow-hidden bg-gray-100 shadow-sm transition-transform duration-300 group-hover:-translate-y-1 ${
+                    compact ? 'rounded-[20px]' : 'rounded-[24px]'
+                  }`}
+                >
                   <img
                     src={feed.imageUrl}
                     alt={feed.title}
                     className="h-full w-full object-cover"
                   />
                 </div>
-
-                <div className="absolute -bottom-5 right-8 flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border-2 border-white bg-white">
-                  <div className="h-2/3 w-2/3 rounded-full">
-                    {feed.avatarUrl ? (
-                      <img
-                        src={feed.avatarUrl}
-                        alt={feed.author}
-                        className="h-full w-full rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="h-full w-full rounded-full bg-[#5D2B26]" />
-                    )}
-                  </div>
-                </div>
               </div>
 
-              <div className="flex items-start justify-between px-1">
+              <div className={`flex items-start justify-between ${compact ? '' : 'px-1'}`}>
                 <div className="flex-1">
                   <div
-                    className="mb-2 flex items-center gap-1 text-gray-500"
+                    className={`flex items-center gap-1 text-gray-500 ${compact ? 'mb-1.5' : 'mb-2'}`}
                     style={{
                       ...typography.body.BodyM,
+                      fontSize: compact ? '13px' : typography.body.BodyM.fontSize,
                     }}
                   >
                     <span>{feed.author}</span>
@@ -89,19 +95,23 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
                   </div>
 
                   <h3
-                    className="mb-3 line-clamp-1 text-gray-900 transition-colors group-hover:text-blue-600"
+                    className={`line-clamp-1 text-gray-900 transition-colors group-hover:text-blue-600 ${
+                      compact ? 'mb-2' : 'mb-3'
+                    }`}
                     style={{
                       ...typography.title.sTitleM,
+                      fontSize: compact ? '20px' : typography.title.sTitleM.fontSize,
                     }}
                   >
                     {feed.title}
                   </h3>
 
-                  <div className="w-2/3">
+                  <div className={compact ? 'w-full' : 'w-2/3'}>
                     <p
-                      className="line-clamp-2 leading-snug text-gray-400"
+                      className={`line-clamp-2 text-gray-400 ${compact ? 'leading-snug' : 'leading-snug'}`}
                       style={{
                         ...typography.body.BodyM,
+                        fontSize: compact ? '14px' : typography.body.BodyM.fontSize,
                       }}
                     >
                       {feed.content}
@@ -109,9 +119,11 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
                   </div>
                 </div>
 
-                <div className="ml-4 flex flex-col items-center">
+                <div className={`${compact ? 'ml-3' : 'ml-4'} flex flex-col items-center`}>
                   <button
-                    className="rounded-full p-2 transition-colors hover:bg-gray-50"
+                    className={`rounded-full transition-colors hover:bg-gray-50 ${
+                      compact ? 'p-1.5' : 'p-2'
+                    }`}
                     onClick={async (event) => {
                       event.stopPropagation();
                       await handleHeartClick(feed.id);
@@ -119,7 +131,11 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
                     }}
                     aria-label={hearts[feed.id] ? '\uC88B\uC544\uC694 \uCDE8\uC18C' : '\uC88B\uC544\uC694'}
                   >
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full border border-gray-200">
+                    <div
+                      className={`flex items-center justify-center rounded-full border border-gray-200 ${
+                        compact ? 'h-10 w-10' : 'h-12 w-12'
+                      }`}
+                    >
                       {hearts[feed.id] ? (
                         <img src={RedHeart} alt="heart" className="w-2/3" />
                       ) : (
@@ -127,7 +143,9 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
                       )}
                     </div>
                   </button>
-                  <span className="mt-[-4px] text-[11px] font-bold text-gray-400">
+                  <span
+                    className={`font-bold text-gray-400 ${compact ? 'mt-[-2px] text-[10px]' : 'mt-[-4px] text-[11px]'}`}
+                  >
                     {(likeCounts[feed.id] ?? feed.likes).toLocaleString()}
                   </span>
                 </div>
@@ -137,18 +155,20 @@ export function FeedGrid({ feeds, onFeedLikeChange }: FeedGridProps) {
         )}
       </div>
 
-      <div className="mt-10 flex justify-center">
-        <button
-          type="button"
-          onClick={() => setShowComingSoon(true)}
-          className="rounded-full border-2 border-[#00c7f2] px-7 py-2.5 text-[#00c7f2] transition-all hover:bg-[#00c7f2] hover:text-white"
-          style={{
-            ...typography.body.BodyM,
-          }}
-        >{'\uB354\uBCF4\uB7EC\uAC00\uAE30'}</button>
-      </div>
+      {showMoreButton ? (
+        <div className="mt-10 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setShowComingSoon(true)}
+            className="rounded-full border-2 border-[#00c7f2] px-7 py-2.5 text-[#00c7f2] transition-all hover:bg-[#00c7f2] hover:text-white"
+            style={{
+              ...typography.body.BodyM,
+            }}
+          >{'\uB354\uBCF4\uB7EC\uAC00\uAE30'}</button>
+        </div>
+      ) : null}
 
-      {showComingSoon ? (
+      {showMoreButton && showComingSoon ? (
         <div className="pointer-events-none fixed bottom-8 left-1/2 z-50 -translate-x-1/2 rounded-2xl bg-[#111827] px-5 py-3 text-sm font-medium text-white shadow-[0_18px_40px_rgba(15,23,42,0.25)]">{'\uC544\uC9C1 \uAC1C\uBC1C\uC911\uC778 \uAE30\uB2A5\uC785\uB2C8\uB2E4.'}</div>
       ) : null}
     </>


### PR DESCRIPTION
﻿## 변경 내용 요약
- 메인페이지 블로그 섹션의 더보러가기 버튼을 전체 목록 페이지 이동으로 연결했습니다.
- `/blogs` 라우트와 블로그 전체 목록 페이지를 추가하고 정렬, 페이지네이션, 상세 이동 흐름을 구현했습니다.
- 목록 페이지에 맞춰 블로그 카드 UI를 4열 컴팩트 레이아웃으로 조정하고 상단 보조 UI와 갈색 원형 배지를 제거했습니다.

## 변경 이유
- 메인페이지에서 본 블로그를 더 탐색할 수 있는 전체 목록 화면이 필요했습니다.
- 목록 페이지에서는 한 번에 더 많은 글을 편하게 볼 수 있도록 레이아웃과 카드 밀도를 조정할 필요가 있었습니다.

## 주요 변경 사항
- 이전: 메인페이지 블로그 섹션에서 더보러가기 동작이 실제 목록 화면으로 이어지지 않았습니다.
- 이후: 더보러가기 클릭 시 `/blogs?sortBy=...&page=1`로 이동하고, 목록에서 정렬과 페이지네이션으로 탐색한 뒤 카드 클릭으로 상세 페이지에 진입할 수 있습니다.
- 공용 `FeedGrid`에 옵션을 추가해 메인페이지와 목록 페이지가 같은 컴포넌트를 다른 밀도로 재사용할 수 있게 했습니다.

## 테스트 방법
- 로그인 후 홈 화면에서 블로그 섹션의 더보러가기를 클릭해 전체 목록 페이지로 이동하는지 확인합니다.
- 목록 페이지에서 최신순/인기순 전환과 페이지 이동이 동작하는지 확인합니다.
- 목록 카드 클릭 시 블로그 상세 페이지로 이동하는지 확인합니다.
- `node .\\node_modules\\nx\\bin\\nx.js typecheck mohang-app` 실행 시 기존 타입 오류로 전체 통과하지 않는 점을 확인합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인증된 사용자를 위한 블로그 목록 페이지 추가
* 페이지네이션 및 정렬 기능 지원
* 홈페이지에서 블로그 목록으로 이동하는 버튼 추가

## 개선
* 피드 그리드 레이아웃 옵션 확장 (컴팩트 모드, 열 커스터마이제이션)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->