### PR TITLE
[FE] 일정 상세 장소 카테고리 스키마 통일

### DIFF
--- a/apps/mohang-app/src/app/pages/PlanDetailPage/components/MapSection.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/components/MapSection.tsx
@@ -5,6 +5,7 @@ import {
   PolylineF,
   InfoWindowF,
 } from '@react-google-maps/api';
+import type { NormalizedSchedulePlace } from '../../../utils/placeSchema';
 
 const mapDarkStyle = [
   { elementType: 'geometry', stylers: [{ color: '#1d2c4d' }] },
@@ -43,13 +44,15 @@ interface MapSectionProps {
   zoom: number;
   onLoad: (map: google.maps.Map) => void;
   path: google.maps.LatLngLiteral[];
-  scheduleItems: any[];
+  scheduleItems: NormalizedSchedulePlace[];
   activeDay: number;
   onZoomIn: () => void;
   onZoomOut: () => void;
   onMarkerClick?: (position: google.maps.LatLngLiteral) => void;
   selectedMarkerId?: string | null;
-  onSelectedMarkerChange?: (marker: any | null) => void;
+  onSelectedMarkerChange?: (
+    marker: (NormalizedSchedulePlace & { index?: number }) | null,
+  ) => void;
 }
 
 const MapSection: React.FC<MapSectionProps> = ({
@@ -68,8 +71,16 @@ const MapSection: React.FC<MapSectionProps> = ({
 }) => {
   const [mapInstance, setMapInstance] = useState<google.maps.Map | null>(null);
   const [markerPhotos, setMarkerPhotos] = useState<Record<string, string>>({});
+  const mappableScheduleItems = scheduleItems.filter(
+    (item): item is NormalizedSchedulePlace & {
+      position: google.maps.LatLngLiteral;
+    } => Boolean(item.position),
+  );
   const selectedMarker =
-    scheduleItems.find((item) => item.id === selectedMarkerId) || null;
+    mappableScheduleItems.find((item) => item.id === selectedMarkerId) || null;
+  const selectedMarkerOrder = selectedMarker
+    ? mappableScheduleItems.findIndex((item) => item.id === selectedMarker.id) + 1
+    : null;
 
   const handleOnLoad = useCallback(
     (map: google.maps.Map) => {
@@ -82,7 +93,7 @@ const MapSection: React.FC<MapSectionProps> = ({
   useEffect(() => {
     if (!selectedMarker || !mapInstance) return;
 
-    const placeId = selectedMarker.place_id || selectedMarker.id;
+    const placeId = selectedMarker.placeId || selectedMarker.id;
     if (markerPhotos[placeId]) return;
 
     const service = new google.maps.places.PlacesService(mapInstance);
@@ -107,12 +118,15 @@ const MapSection: React.FC<MapSectionProps> = ({
     );
   }, [selectedMarker, mapInstance]);
 
-  const handleMarkerClick = (marker: any, idx: number) => {
+  const handleMarkerClick = (
+    marker: NormalizedSchedulePlace & { position: google.maps.LatLngLiteral },
+    idx: number,
+  ) => {
     const nextMarker = { ...marker, index: idx + 1 };
 
     const isSameMarker =
       selectedMarkerId === nextMarker.id ||
-      selectedMarkerId === nextMarker.place_id;
+      selectedMarkerId === nextMarker.placeId;
 
     onSelectedMarkerChange?.(isSameMarker ? null : nextMarker);
 
@@ -139,7 +153,7 @@ const MapSection: React.FC<MapSectionProps> = ({
             strokeWeight: 4,
           }}
         />
-        {scheduleItems.map((marker, idx) => (
+        {mappableScheduleItems.map((marker, idx) => (
           <MarkerF
             key={`day-${activeDay}-marker-${marker.id}`}
             position={marker.position}
@@ -168,16 +182,16 @@ const MapSection: React.FC<MapSectionProps> = ({
                   rel="noopener noreferrer"
                   className="block group"
                 >
-                  {markerPhotos[selectedMarker.place_id || selectedMarker.id] ? (
+                  {markerPhotos[selectedMarker.placeId || selectedMarker.id] ? (
                     <div className="relative h-32 w-full overflow-hidden">
                       <img
-                        src={markerPhotos[selectedMarker.place_id || selectedMarker.id]}
+                        src={markerPhotos[selectedMarker.placeId || selectedMarker.id]}
                         alt={selectedMarker.title}
                         className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
                       />
                       <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
                       <div className="absolute top-2 left-2 bg-sky-500 text-white text-[10px] font-bold px-2 py-0.5 rounded-full shadow-md z-10">
-                        Day {activeDay} - {selectedMarker.index}
+                        Day {activeDay} - {selectedMarkerOrder}
                       </div>
                       <div className="absolute bottom-2 right-2 bg-white/90 backdrop-blur-sm p-1.5 rounded-full shadow-sm opacity-0 group-hover:opacity-100 transition-opacity">
                         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#0ea5e9" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -201,6 +215,17 @@ const MapSection: React.FC<MapSectionProps> = ({
                     <h3 className="font-bold text-gray-900 text-[14px] mb-1.5 line-clamp-1 group-hover:text-sky-600 transition-colors">
                       {selectedMarker.title}
                     </h3>
+                    <div className="mb-2">
+                      <span
+                        className={`inline-flex rounded-full border px-2 py-1 text-[10px] font-bold ${
+                          selectedMarker.isCategoryFallback
+                            ? 'border-gray-200 bg-gray-100 text-gray-500'
+                            : 'border-sky-100 bg-sky-50 text-sky-600'
+                        }`}
+                      >
+                        {selectedMarker.placeCategoryLabel}
+                      </span>
+                    </div>
                     <div className="flex items-center gap-1.5 mb-1.5 text-sky-500">
                       <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
                         <circle cx="12" cy="12" r="10" />
@@ -212,6 +237,9 @@ const MapSection: React.FC<MapSectionProps> = ({
                     </div>
                     <p className="text-gray-500 text-[10px] leading-relaxed line-clamp-2">
                       {selectedMarker.location}
+                    </p>
+                    <p className="mt-1 text-gray-400 text-[10px] leading-relaxed line-clamp-2">
+                      {selectedMarker.description || '장소 설명이 아직 없어요.'}
                     </p>
                     <div className="mt-3 pt-2 border-t border-gray-50 flex items-center gap-1">
                       <span className="text-sky-500 text-[11px] font-semibold hover:underline cursor-pointer flex items-center gap-1">

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/components/ScheduleSidebar.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/components/ScheduleSidebar.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
-
-interface ScheduleItem {
-  id: string;
-  title: string;
-  time: string;
-  location: string;
-  description?: string;
-  position: google.maps.LatLngLiteral;
-}
+import type { NormalizedSchedulePlace } from '../../../utils/placeSchema';
 
 interface ScheduleSidebarProps {
   activeDay: number;
-  scheduleItems: ScheduleItem[];
+  scheduleItems: NormalizedSchedulePlace[];
   onAddToMyPlan: () => void;
-  onItemClick?: (item: ScheduleItem) => void;
+  onItemClick?: (item: NormalizedSchedulePlace) => void;
   date?: string;
   isMyPlan?: boolean;
   isCompleted?: boolean;
@@ -73,11 +65,23 @@ const ScheduleSidebar: React.FC<ScheduleSidebarProps> = ({
                 <span className="font-bold text-[15px] text-gray-800">
                   {item.title}
                 </span>
+                <span
+                  className={`mt-2 inline-flex w-fit items-center rounded-full border px-2.5 py-1 text-[10px] font-bold ${
+                    item.isCategoryFallback
+                      ? 'border-gray-200 bg-gray-100 text-gray-500'
+                      : 'border-sky-100 bg-sky-50 text-sky-600'
+                  }`}
+                >
+                  {item.placeCategoryLabel}
+                </span>
                 <span className="text-sky-500 text-[11px] font-black mt-1 uppercase">
                   {item.time}
                 </span>
                 <p className="text-gray-400 text-[10px] mt-1 font-medium leading-relaxed">
-                  {item.description || item.location}
+                  {item.location}
+                </p>
+                <p className="text-gray-500 text-[10px] mt-1 font-medium leading-relaxed">
+                  {item.description || '장소 설명이 아직 없어요.'}
                 </p>
               </div>
             </div>

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -21,6 +21,11 @@ import {
   updateCourseCompletion,
   copyCourse,
 } from '@mohang/ui';
+import {
+  normalizeItineraryDays,
+  type NormalizedSchedulePlace,
+  type RawItineraryDay,
+} from '../../utils/placeSchema';
 
 const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
 const apiBaseUrl = import.meta.env.VITE_PROD_BASE_URL || 'https://api.mohaeng.kr';
@@ -125,6 +130,25 @@ const resolveIsMyPlan = ({
   );
 };
 
+interface ItineraryInfo {
+  itinerary: RawItineraryDay[] | null;
+  title: string;
+  startDate: string;
+  endDate: string;
+  nights: number;
+  tripDays: number;
+  peopleCount: number;
+  tags: string[];
+  isMyPlan: boolean;
+  authorName?: string;
+  isEdited?: boolean;
+  tasteMatch?: string;
+  summary?: any;
+  llmCommentary?: any;
+  isCompleted?: boolean;
+  is_completed?: boolean;
+}
+
 const PlanDetailPage = () => {
   const [activeDay, setActiveDay] = useState<number>(1);
   const [zoom, setZoom] = useState(14);
@@ -147,9 +171,9 @@ const PlanDetailPage = () => {
   const [travelCourseId, setTravelCourseId] = useState<string>('');
   const [tabPageIndex, setTabPageIndex] = useState(0);
   const [isScheduleSidebarOpen, setIsScheduleSidebarOpen] = useState(true);
-  const [selectedScheduleItem, setSelectedScheduleItem] = useState<any | null>(
-    null,
-  );
+  const [selectedScheduleItem, setSelectedScheduleItem] = useState<
+    (NormalizedSchedulePlace & { index?: number }) | null
+  >(null);
 
   const [isLoading, setIsLoading] = useState(true);
   const [loadingMessage, setLoadingMessage] =
@@ -177,25 +201,6 @@ const PlanDetailPage = () => {
         .catch((err) => console.error('Failed to fetch user:', err));
     }
   }, []);
-
-  interface ItineraryInfo {
-    itinerary: any[] | null;
-    title: string;
-    startDate: string;
-    endDate: string;
-    nights: number;
-    tripDays: number;
-    peopleCount: number;
-    tags: string[];
-    isMyPlan: boolean;
-    authorName?: string;
-    isEdited?: boolean;
-    tasteMatch?: string;
-    summary?: any;
-    llmCommentary?: any;
-    isCompleted?: boolean;
-    is_completed?: boolean;
-  }
 
   const [itineraryData, setItineraryData] = useState<ItineraryInfo>({
     itinerary: null,
@@ -227,35 +232,34 @@ const PlanDetailPage = () => {
     }
   }, [currentUser, itineraryData.authorName, itineraryData.isEdited, itineraryData.isMyPlan]);
 
-  const [scheduleData, setScheduleData] = useState<Record<number, any[]>>({});
+  const [scheduleData, setScheduleData] = useState<
+    Record<number, NormalizedSchedulePlace[]>
+  >({});
 
   useEffect(() => {
     if (!itineraryData.itinerary) return;
 
-    const formattedData: Record<number, any[]> = {};
+    const formattedData: Record<number, NormalizedSchedulePlace[]> = {};
+    const normalizedItinerary = normalizeItineraryDays(itineraryData.itinerary);
 
-    itineraryData.itinerary.forEach((day: any) => {
-      formattedData[day.day_number] = day.places.map((place: any, pIdx: number) => ({
-        id: place.id || `${place.place_id}-${day.day_number}-${pIdx}`,
-        place_id: place.place_id,
-        title: place.place_name,
-        position: {
-          lat: Number(place.latitude),
-          lng: Number(place.longitude),
-        },
-        time: place.visit_time,
-        location: place.address,
-        description: place.description,
-      }));
+    normalizedItinerary.forEach((day: {
+      dayNumber: number;
+      places: NormalizedSchedulePlace[];
+    }) => {
+      formattedData[day.dayNumber] = day.places;
     });
 
     setScheduleData(formattedData);
 
     if (Object.keys(formattedData).length > 0) {
-      setActiveDay(1);
+      const firstDayNumber = normalizedItinerary[0]?.dayNumber ?? 1;
       setSelectedScheduleItem(null);
-      if (formattedData[1]?.[0]?.position) {
-        setMapCenter(formattedData[1][0].position);
+      setActiveDay(firstDayNumber);
+      const firstMappablePlace = formattedData[firstDayNumber]?.find(
+        (place) => place.position,
+      );
+      if (firstMappablePlace?.position) {
+        setMapCenter(firstMappablePlace.position);
       }
     }
   }, [itineraryData.itinerary]);
@@ -631,15 +635,22 @@ const PlanDetailPage = () => {
   };
 
   const path = useMemo(
-    () => scheduleData[activeDay]?.map((m) => m.position) || [],
+    () =>
+      scheduleData[activeDay]?.flatMap((item) =>
+        item.position ? [item.position] : [],
+      ) || [],
     [scheduleData, activeDay],
   );
 
-  const handleFocusLocation = (item: any) => {
-    const isSameItem = selectedScheduleItem?.id === item.id || selectedScheduleItem?.place_id === item.place_id;
+  const handleFocusLocation = (item: NormalizedSchedulePlace) => {
+    const isSameItem =
+      selectedScheduleItem?.id === item.id ||
+      selectedScheduleItem?.placeId === item.placeId;
     setSelectedScheduleItem(isSameItem ? null : item);
-    setMapCenter(item.position);
-    setZoom(16);
+    if (item.position) {
+      setMapCenter(item.position);
+      setZoom(16);
+    }
   };
 
   return (
@@ -798,8 +809,11 @@ const PlanDetailPage = () => {
                       key={idx}
                       onClick={() => {
                         setActiveDay(idx + 1);
-                        if (scheduleData[idx + 1]?.[0]?.position) {
-                          setMapCenter(scheduleData[idx + 1][0].position);
+                        const firstMappablePlace = scheduleData[idx + 1]?.find(
+                          (place) => place.position,
+                        );
+                        if (firstMappablePlace?.position) {
+                          setMapCenter(firstMappablePlace.position);
                           setZoom(14);
                         }
                       }}

--- a/apps/mohang-app/src/app/pages/TripDetailPage.tsx
+++ b/apps/mohang-app/src/app/pages/TripDetailPage.tsx
@@ -1,21 +1,51 @@
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useAlert } from '../context/AlertContext';
-import { getCourseDetail, LoadingScreen, updateCourseCompletion, copyCourse, addLike, removeLike, getAccessToken, getMainPageUser, UserResponse } from '@mohang/ui';
-
-interface ScheduleItem {
-  time: string;
-  location: string;
-  description: string;
-  coordinates?: { lat: number; lng: number };
-  order: number;
-}
+import {
+  addLike,
+  copyCourse,
+  getAccessToken,
+  getCourseDetail,
+  getMainPageUser,
+  LoadingScreen,
+  removeLike,
+  updateCourseCompletion,
+  UserResponse,
+} from '@mohang/ui';
+import {
+  normalizeItineraryDays,
+  type NormalizedSchedulePlace,
+} from '../utils/placeSchema';
 
 interface DaySchedule {
   day: number;
   date: string;
-  items: ScheduleItem[];
+  items: NormalizedSchedulePlace[];
 }
+
+const createInfoWindowContent = (
+  item: NormalizedSchedulePlace,
+  index: number,
+) => `
+  <div style="min-width: 180px; padding: 8px 10px;">
+    <div style="display: inline-flex; border-radius: 9999px; padding: 4px 8px; font-size: 10px; font-weight: 700; ${
+      item.isCategoryFallback
+        ? 'background: #f3f4f6; color: #6b7280; border: 1px solid #e5e7eb;'
+        : 'background: #ecfeff; color: #0284c7; border: 1px solid #bae6fd;'
+    }">
+      ${item.placeCategoryLabel}
+    </div>
+    <div style="margin-top: 8px; font-size: 14px; font-weight: 700; color: #111827;">
+      ${index + 1}. ${item.title}
+    </div>
+    <div style="margin-top: 6px; font-size: 12px; font-weight: 700; color: #0ea5e9;">
+      ${item.time}
+    </div>
+    <div style="margin-top: 6px; font-size: 12px; color: #6b7280; line-height: 1.4;">
+      ${item.location}
+    </div>
+  </div>
+`;
 
 // Sample mock data removed as we move to real API data.
 
@@ -76,7 +106,21 @@ export function TripDetailPage() {
         if (!data) return;
         
         setCourseData(data);
+        const normalizedSchedule = normalizeItineraryDays(
+          data.itinerary || [],
+        ).map((day: {
+          dayNumber: number;
+          dailyDate: string;
+          places: NormalizedSchedulePlace[];
+        }) => ({
+          day: day.dayNumber,
+          date: day.dailyDate || `Day ${day.dayNumber}`,
+          items: day.places,
+        }));
 
+        setSchedule(normalizedSchedule);
+
+        /*
         // Group places by day_number (already grouped in itinerary)
         const sortedSchedule = (data.itinerary || []).map((day) => ({
           day: day.day_number,
@@ -94,6 +138,7 @@ export function TripDetailPage() {
         }));
         
         setSchedule(sortedSchedule);
+        */
       } catch (error) {
         console.error('getCourseDetail Error:', error);
       } finally {
@@ -128,8 +173,9 @@ export function TripDetailPage() {
       // InfoWindow를 애니메이션 후에 열기
       setTimeout(() => {
         if (!currentSchedule || !currentSchedule.items[index]) return;
+        const selectedItem = currentSchedule.items[index];
         const infoWindow = new google.maps.InfoWindow({
-          content: `<div style="padding: 8px;"><b>${index + 1}. ${currentSchedule.items[index].location}</b><br/>${currentSchedule.items[index].time}</div>`,
+          content: createInfoWindowContent(selectedItem, index),
         });
         infoWindow.open(map, markersRef.current[index]);
         infoWindowRef.current = infoWindow;
@@ -225,9 +271,7 @@ export function TripDetailPage() {
 
       if (!currentSchedule) return false;
 
-      const locations = currentSchedule.items.filter(
-        (item) => item.coordinates,
-      );
+      const locations = currentSchedule.items.filter((item) => item.position);
       if (locations.length === 0) return false;
 
       // 기존 InfoWindow 닫기
@@ -260,7 +304,7 @@ export function TripDetailPage() {
       // 좌표가 같은 위치들을 그룹화
       const locationGroups = new Map<string, number[]>();
       locations.forEach((item, index) => {
-        const key = `${item.coordinates!.lat},${item.coordinates!.lng}`;
+        const key = `${item.position!.lat},${item.position!.lng}`;
         if (!locationGroups.has(key)) {
           locationGroups.set(key, []);
         }
@@ -269,7 +313,7 @@ export function TripDetailPage() {
 
       // 마커 추가
       locations.forEach((item, index) => {
-        const key = `${item.coordinates!.lat},${item.coordinates!.lng}`;
+        const key = `${item.position!.lat},${item.position!.lng}`;
         const group = locationGroups.get(key)!;
         const isSameLocation = group.length > 1;
 
@@ -288,11 +332,11 @@ export function TripDetailPage() {
 
           marker = new google.maps.Marker({
             position: {
-              lat: item.coordinates!.lat,
-              lng: item.coordinates!.lng,
+              lat: item.position!.lat,
+              lng: item.position!.lng,
             },
             map: map,
-            title: item.location,
+            title: item.title,
             icon: circleIcon,
           });
         } else {
@@ -308,11 +352,11 @@ export function TripDetailPage() {
 
           marker = new google.maps.Marker({
             position: {
-              lat: item.coordinates!.lat,
-              lng: item.coordinates!.lng,
+              lat: item.position!.lat,
+              lng: item.position!.lng,
             },
             map: map,
-            title: item.location,
+            title: item.title,
             icon: blueIcon,
             label: {
               text: String(index + 1),
@@ -332,15 +376,15 @@ export function TripDetailPage() {
           }
 
           const infoWindow = new google.maps.InfoWindow({
-            content: `<div style="padding: 8px;"><b>${index + 1}. ${item.location}</b><br/>${item.time}</div>`,
+            content: createInfoWindowContent(item, index),
           });
           infoWindow.open(map, marker);
           infoWindowRef.current = infoWindow;
         });
 
         bounds.extend({
-          lat: item.coordinates!.lat,
-          lng: item.coordinates!.lng,
+          lat: item.position!.lat,
+          lng: item.position!.lng,
         });
       });
 
@@ -389,14 +433,8 @@ export function TripDetailPage() {
 
         // 각 구간별로 polyline 생성
         for (let i = 0; i < locations.length - 1; i++) {
-          const start = {
-            lat: locations[i].coordinates!.lat,
-            lng: locations[i].coordinates!.lng,
-          };
-          const end = {
-            lat: locations[i + 1].coordinates!.lat,
-            lng: locations[i + 1].coordinates!.lng,
-          };
+          const start = locations[i].position!;
+          const end = locations[i + 1].position!;
 
           // 같은 좌표면 선 그리지 않음
           if (start.lat === end.lat && start.lng === end.lng) {
@@ -687,10 +725,10 @@ export function TripDetailPage() {
                   <div
                     className="flex gap-4 p-4 rounded-xl hover:bg-gray-50 transition-colors cursor-pointer group"
                     onClick={() =>
-                      item.coordinates &&
+                      item.position &&
                       handleLocationClick(
-                        item.coordinates.lat,
-                        item.coordinates.lng,
+                        item.position.lat,
+                        item.position.lng,
                         index,
                       )
                     }
@@ -707,11 +745,23 @@ export function TripDetailPage() {
                     {/* 내용 */}
                     <div className="flex-1 min-w-0 pt-1">
                       <h3 className="font-bold text-gray-900 mb-1 group-hover:text-blue-600 transition-colors">
-                        {item.location}
+                        {item.title}
                       </h3>
+                      <span
+                        className={`mb-2 inline-flex rounded-full border px-2.5 py-1 text-[10px] font-bold ${
+                          item.isCategoryFallback
+                            ? 'border-gray-200 bg-gray-100 text-gray-500'
+                            : 'border-sky-100 bg-sky-50 text-sky-600'
+                        }`}
+                      >
+                        {item.placeCategoryLabel}
+                      </span>
                       <p className="text-sm text-gray-500 mb-1">{item.time}</p>
+                      <p className="text-sm text-gray-500 mb-1">
+                        {item.location}
+                      </p>
                       <p className="text-sm text-gray-600 leading-relaxed">
-                        {item.description}
+                        {item.description || '장소 설명이 아직 없어요.'}
                       </p>
                     </div>
                   </div>

--- a/apps/mohang-app/src/app/utils/placeSchema.ts
+++ b/apps/mohang-app/src/app/utils/placeSchema.ts
@@ -1,0 +1,207 @@
+export const PLACE_CATEGORY_FALLBACK_CODE = 'OTHER';
+export const PLACE_CATEGORY_FALLBACK_LABEL = '기타 장소';
+
+const PLACE_CATEGORY_ALIASES: Record<string, string> = {
+  ATTRACTION: 'TOURIST_ATTRACTION',
+  CULTURAL: 'CULTURAL_SITE',
+  CULTURE: 'CULTURAL_SITE',
+  DINING: 'RESTAURANT',
+  EXPERIENCES: 'EXPERIENCE',
+  FOOD: 'RESTAURANT',
+  HISTORY: 'HISTORICAL_SITE',
+  HOTEL: 'ACCOMMODATION',
+  LANDSCAPE: 'NATURE',
+  LODGING: 'ACCOMMODATION',
+  LOCAL_EXPERIENCE: 'EXPERIENCE',
+  NATURAL: 'NATURE',
+  STAY: 'ACCOMMODATION',
+  TOURIST_SPOT: 'TOURIST_ATTRACTION',
+  TOURIST_SPOTS: 'TOURIST_ATTRACTION',
+  TRANSIT: 'TRANSPORTATION',
+  UNKNOWN: PLACE_CATEGORY_FALLBACK_CODE,
+};
+
+export const PLACE_CATEGORY_LABELS: Record<string, string> = {
+  ACCOMMODATION: '숙소',
+  ACTIVITY: '액티비티',
+  BAR: '바',
+  BEACH: '해변',
+  CAFE: '카페',
+  CULTURAL_SITE: '문화 명소',
+  EXPERIENCE: '체험',
+  GALLERY: '전시 공간',
+  HISTORICAL_SITE: '역사 명소',
+  LANDMARK: '랜드마크',
+  MARKET: '시장',
+  MUSEUM: '박물관',
+  NATURE: '자연 명소',
+  NIGHTLIFE: '야간 명소',
+  OTHER: PLACE_CATEGORY_FALLBACK_LABEL,
+  PARK: '공원',
+  RELIGIOUS_SITE: '종교 명소',
+  RESTAURANT: '음식점',
+  SHOPPING: '쇼핑',
+  SHOPPING_MALL: '쇼핑몰',
+  TOURIST_ATTRACTION: '관광 명소',
+  TRANSPORTATION: '교통',
+  VIEWPOINT: '전망 포인트',
+};
+
+export interface RawItineraryPlace {
+  id?: string | number | null;
+  place_id?: string | null;
+  place_name?: string | null;
+  address?: string | null;
+  latitude?: string | number | null;
+  longitude?: string | number | null;
+  place_url?: string | null;
+  description?: string | null;
+  visit_sequence?: number | null;
+  visit_time?: string | null;
+  place_category?: string | null;
+  primary_type?: string | null;
+}
+
+export interface RawItineraryDay {
+  day_number?: number | null;
+  daily_date?: string | null;
+  places?: RawItineraryPlace[] | null;
+}
+
+export interface PlaceMapPosition {
+  lat: number;
+  lng: number;
+}
+
+export interface NormalizedSchedulePlace {
+  id: string;
+  placeId: string | null;
+  title: string;
+  location: string;
+  description: string;
+  time: string;
+  position?: PlaceMapPosition;
+  placeUrl: string | null;
+  visitSequence: number | null;
+  placeCategory: string;
+  placeCategoryLabel: string;
+  isCategoryFallback: boolean;
+}
+
+export interface NormalizedItineraryDay {
+  dayNumber: number;
+  dailyDate: string;
+  places: NormalizedSchedulePlace[];
+}
+
+const normalizeNumericValue = (value: string | number | null | undefined) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+};
+
+export const normalizePlaceCategoryCode = (
+  categoryCode: string | null | undefined,
+) => {
+  const normalizedCode = String(categoryCode || '')
+    .trim()
+    .toUpperCase();
+
+  if (!normalizedCode) {
+    return PLACE_CATEGORY_FALLBACK_CODE;
+  }
+
+  return PLACE_CATEGORY_ALIASES[normalizedCode] || normalizedCode;
+};
+
+const getPlaceCategoryInfo = (categoryCode: string | null | undefined) => {
+  const normalizedCode = normalizePlaceCategoryCode(categoryCode);
+  const label = PLACE_CATEGORY_LABELS[normalizedCode];
+
+  if (label) {
+    return {
+      code: normalizedCode,
+      label,
+      isFallback: normalizedCode === PLACE_CATEGORY_FALLBACK_CODE,
+    };
+  }
+
+  return {
+    code: PLACE_CATEGORY_FALLBACK_CODE,
+    label: PLACE_CATEGORY_FALLBACK_LABEL,
+    isFallback: true,
+  };
+};
+
+export const normalizeSchedulePlace = (
+  place: RawItineraryPlace,
+  options?: { dayNumber?: number; index?: number },
+): NormalizedSchedulePlace => {
+  const lat = normalizeNumericValue(place.latitude);
+  const lng = normalizeNumericValue(place.longitude);
+  const position =
+    lat !== null && lng !== null
+      ? {
+          lat,
+          lng,
+        }
+      : undefined;
+  const category = getPlaceCategoryInfo(
+    place.place_category ?? place.primary_type,
+  );
+  const fallbackId = [
+    place.place_id || 'place',
+    options?.dayNumber ?? 'day',
+    options?.index ?? 'idx',
+  ].join('-');
+
+  return {
+    id: String(place.id ?? fallbackId),
+    placeId: place.place_id ?? null,
+    title: String(place.place_name || '').trim() || '이름 없는 장소',
+    location:
+      String(place.address || '').trim() ||
+      String(place.place_name || '').trim() ||
+      '위치 정보 없음',
+    description: String(place.description || '').trim(),
+    time:
+      String(place.visit_time || '').trim() ||
+      (typeof place.visit_sequence === 'number'
+        ? `${place.visit_sequence}번째 방문`
+        : '시간 미정'),
+    position,
+    placeUrl: place.place_url ?? null,
+    visitSequence:
+      typeof place.visit_sequence === 'number' ? place.visit_sequence : null,
+    placeCategory: category.code,
+    placeCategoryLabel: category.label,
+    isCategoryFallback: category.isFallback,
+  };
+};
+
+export const normalizeItineraryDays = (
+  itinerary: RawItineraryDay[] | null | undefined,
+) =>
+  (itinerary || []).map((day, dayIndex): NormalizedItineraryDay => ({
+    dayNumber:
+      typeof day.day_number === 'number' && Number.isFinite(day.day_number)
+        ? day.day_number
+        : dayIndex + 1,
+    dailyDate: String(day.daily_date || '').trim(),
+    places: (day.places || []).map((place, placeIndex) =>
+      normalizeSchedulePlace(place, {
+        dayNumber:
+          typeof day.day_number === 'number' && Number.isFinite(day.day_number)
+            ? day.day_number
+            : dayIndex + 1,
+        index: placeIndex,
+      }),
+    ),
+  }));

--- a/libs/ui/src/api/Itineraries.ts
+++ b/libs/ui/src/api/Itineraries.ts
@@ -38,6 +38,8 @@ export interface ItineraryPlace {
   description: string;
   visit_sequence: number;
   visit_time: any;
+  place_category?: string | null;
+  primary_type?: string | null;
 }
 
 /**

--- a/libs/ui/src/api/courses.type.ts
+++ b/libs/ui/src/api/courses.type.ts
@@ -63,6 +63,8 @@ export interface CourseDetailPlace {
   description: string;
   visit_sequence: number;
   visit_time: any;
+  place_category?: string | null;
+  primary_type?: string | null;
 }
 
 /**


### PR DESCRIPTION
## 변경 내용 요약
- 일정 상세 장소 카드와 지도 상세가 `primary_type` 대신 `place_category`를 기준으로 동작하도록 정리했습니다.
- 장소 카테고리 영문 코드에 대한 한글 라벨 매핑과 `OTHER` fallback UI를 추가했습니다.
- 로드맵 생성 결과와 채팅 수정 결과를 동일한 장소 정규화 스키마로 처리하도록 맞췄습니다.

## 변경 이유
- 장소 응답 스키마가 `place_category` 중심으로 정리되는 상황에서 상세 화면이 기존 필드 분기에 의존하고 있어 표시 일관성이 깨지고 있었습니다.
- 생성 결과와 수정 결과가 같은 장소 데이터를 사용하더라도 UI 해석 방식이 달라질 수 있어 공통 정규화가 필요했습니다.

## 주요 변경 사항
- `PlanDetailPage`와 `TripDetailPage`에 공통 장소 정규화 유틸을 적용해 제목, 시간, 주소, 좌표, 카테고리 라벨을 같은 방식으로 파생하도록 변경했습니다.
- 장소 카드와 지도 InfoWindow에 카테고리 배지를 추가하고, `OTHER` 또는 미정 카테고리일 때는 fallback 스타일과 문구를 표시하도록 했습니다.
- 기존 `primary_type` 의존 로직은 제거하고, 하위 호환이 필요한 경우에만 정규화 단계에서 `place_category`의 보조 fallback으로만 사용되도록 제한했습니다.

## 테스트 방법
- `tsc -p libs/ui/tsconfig.lib.json --noEmit`
- `tsc -p apps/mohang-app/tsconfig.app.json --noEmit`
- 참고: 두 번째 타입체크는 이번 변경과 무관한 기존 오류로 실패합니다.
- 기존 오류 위치: `apps/mohang-app/src/app/pages/DiscoverPage.tsx`, `apps/mohang-app/src/app/pages/LandingPage.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 여행 계획 지도 및 일정 목록의 장소 정보 표시 개선
  * 각 장소에 카테고리 배지 추가
  * 장소 설명이 없을 때 기본 메시지 표시
  * 지도 마커 선택 및 위치 포커싱 기능 개선
  * 일정 상세 정보 창(InfoWindow)에 카테고리, 제목, 시간, 위치 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->