### PR TITLE
[FE] 좋아요 즉시 반영과 상태 원복 버그 수정

### DIFF
--- a/apps/mohang-app/src/app/pages/BlogListPage.tsx
+++ b/apps/mohang-app/src/app/pages/BlogListPage.tsx
@@ -10,6 +10,7 @@ import {
   type GridFeedItem,
   typography,
 } from '@mohang/ui';
+import { useAlert } from '../context/AlertContext';
 
 const PAGE_SIZE = 12;
 const FALLBACK_BLOG_IMAGE =
@@ -40,6 +41,7 @@ const createPageRange = (currentPage: number, totalPages: number) => {
 export function BlogListPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const isLoggedIn = Boolean(getAccessToken());
+  const { showAlert } = useAlert();
 
   const sortBy = getSafeSort(searchParams.get('sortBy'));
   const currentPage = getSafePage(searchParams.get('page'));
@@ -208,6 +210,7 @@ export function BlogListPage() {
               showMoreButton={false}
               desktopColumns={4}
               compact
+              onLikeError={(message) => showAlert(message, 'error')}
             />
 
             <div className="mt-12 flex flex-col items-center gap-4">

--- a/apps/mohang-app/src/app/pages/DiscoverPage.tsx
+++ b/apps/mohang-app/src/app/pages/DiscoverPage.tsx
@@ -11,6 +11,7 @@ import {
   useSurvey,
 } from '@mohang/ui';
 import type { FeedItem } from '@mohang/ui';
+import { useAlert } from '../context/AlertContext';
 
 interface CountryOption {
   id?: string;
@@ -36,6 +37,7 @@ const FIXED_FILTER_COUNTRY_CODES = new Set(
 
 export function DiscoverPage() {
   const { surveyData, updateSurveyData } = useSurvey();
+  const { showAlert } = useAlert();
   const [countries, setCountries] = useState<CountryOption[]>([]);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [destinations, setDestinations] = useState<Destination[]>([]);
@@ -345,6 +347,7 @@ export function DiscoverPage() {
             <DestinationList
               destinations={destinations}
               feeds={feeds}
+              onLikeError={(message) => showAlert(message, 'error')}
               page={currentPage}
               totalPages={paginationInfo.totalPages}
               onPageChange={setCurrentPage}

--- a/apps/mohang-app/src/app/pages/HomePage.tsx
+++ b/apps/mohang-app/src/app/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { colors, typography } from '@mohang/ui';
+import { useAlert } from '../context/AlertContext';
 import {
   Header,
   TravelCard,
@@ -111,6 +112,7 @@ const mapPreferenceRecommendation = (
 export function HomePage({ initialUser }: HomePageProps) {
   const location = useLocation();
   const navigate = useNavigate();
+  const { showAlert } = useAlert();
   const [selectedCountry, setSelectedCountry] = useState('JP');
   const [sortBy, setSortBy] = useState<'latest' | 'popular'>('latest');
   const [blogSortBy, setBlogSortBy] = useState<'latest' | 'popular'>('latest');
@@ -500,6 +502,7 @@ export function HomePage({ initialUser }: HomePageProps) {
             <DestinationList
               destinations={destinations}
               feeds={feeds}
+              onLikeError={(message) => showAlert(message, 'error')}
               page={currentPage}
               totalPages={paginationInfo.totalPages}
               onPageChange={setCurrentPage}
@@ -516,7 +519,11 @@ export function HomePage({ initialUser }: HomePageProps) {
               </div>
             ) : (
               <>
-                <FeedGrid feeds={feeds} showMoreButton={false} />
+                <FeedGrid
+                  feeds={feeds}
+                  showMoreButton={false}
+                  onLikeError={(message) => showAlert(message, 'error')}
+                />
                 {feeds.length > 0 ? (
                   <div className="mt-10 flex justify-center">
                     <button

--- a/apps/mohang-app/src/app/pages/MyPage.tsx
+++ b/apps/mohang-app/src/app/pages/MyPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { FeedItem, clearTokens, getAccessToken } from '@mohang/ui';
 import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useAlert } from '../context/AlertContext';
 import {
   getMyRoadmaps,
   getMyTravelLogs,
@@ -17,6 +18,7 @@ interface MyPageProps {
 
 export function MyPage({ initialUser }: MyPageProps) {
   const navigate = useNavigate();
+  const { showAlert } = useAlert();
   const token = getAccessToken();
   const isLoggedIn = Boolean(token && token !== 'undefined');
   const [myRoadmaps, setMyRoadmaps] = useState<any>([]);
@@ -239,6 +241,7 @@ export function MyPage({ initialUser }: MyPageProps) {
       <MyPageComponent
         userName={userData.name}
         feeds={sampleFeeds}
+        onLikeError={(message) => showAlert(message, 'error')}
         destinations={userDestinations}
         travelLogs={userTravelLogs}
         likedRoadmaps={userLikedRoadmaps}

--- a/apps/mohang-app/src/app/useLikeCounts.spec.tsx
+++ b/apps/mohang-app/src/app/useLikeCounts.spec.tsx
@@ -20,17 +20,20 @@ function LikeHarness({
   feeds,
   onLike,
   onUnlike,
+  onError,
   persistKey,
 }: {
   feeds: FeedItem[];
   onLike?: (id: string) => Promise<unknown>;
   onUnlike?: (id: string) => Promise<unknown>;
+  onError?: (message: string) => void;
   persistKey?: string;
 }) {
   const { hearts, likeCounts, handleHeartClick } = useLikeCounts({
     feeds,
     onLike,
     onUnlike,
+    onError,
     persistKey,
   });
 
@@ -129,5 +132,36 @@ describe('useLikeCounts', () => {
       expect(screen.getByTestId('liked').textContent).toBe('true'),
     );
     expect(screen.getByTestId('count').textContent).toBe('11');
+  });
+
+  it('uses the custom error handler instead of window.alert on failure', async () => {
+    const onError = vi.fn();
+    const onLike = vi.fn().mockRejectedValue(new Error('커스텀 실패 안내'));
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <LikeHarness
+        feeds={[baseFeed]}
+        onLike={onLike}
+        onError={onError}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith('커스텀 실패 안내'),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('liked').textContent).toBe('false'),
+    );
+    expect(screen.getByTestId('count').textContent).toBe('10');
+    expect(alertSpy).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/mohang-app/src/app/useLikeCounts.spec.tsx
+++ b/apps/mohang-app/src/app/useLikeCounts.spec.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import {
+  type FeedItem,
+  useLikeCounts,
+} from '../../../../libs/ui/src/hooks/useLikeCounts';
+
+const baseFeed: FeedItem = {
+  id: 'blog-1',
+  author: 'tester',
+  date: '2026-05-04',
+  title: 'Blog title',
+  content: 'Blog content',
+  imageUrl: 'https://example.com/image.jpg',
+  likes: 10,
+  isLiked: false,
+};
+
+function LikeHarness({
+  feeds,
+  onLike,
+  onUnlike,
+  persistKey,
+}: {
+  feeds: FeedItem[];
+  onLike?: (id: string) => Promise<unknown>;
+  onUnlike?: (id: string) => Promise<unknown>;
+  persistKey?: string;
+}) {
+  const { hearts, likeCounts, handleHeartClick } = useLikeCounts({
+    feeds,
+    onLike,
+    onUnlike,
+    persistKey,
+  });
+
+  const feed = feeds[0];
+
+  return (
+    <div>
+      <div data-testid="liked">{String(hearts[feed.id] ?? feed.isLiked ?? false)}</div>
+      <div data-testid="count">{String(likeCounts[feed.id] ?? feed.likes)}</div>
+      <button type="button" onClick={() => void handleHeartClick(feed.id)}>
+        toggle
+      </button>
+    </div>
+  );
+}
+
+describe('useLikeCounts', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('keeps the optimistic state until incoming feed data catches up', async () => {
+    const onLike = vi.fn().mockResolvedValue(undefined);
+    const { rerender } = render(
+      <LikeHarness feeds={[baseFeed]} onLike={onLike} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    await waitFor(() => expect(onLike).toHaveBeenCalledWith(baseFeed.id));
+    await waitFor(() =>
+      expect(screen.getByTestId('liked').textContent).toBe('true'),
+    );
+    expect(screen.getByTestId('count').textContent).toBe('11');
+
+    rerender(<LikeHarness feeds={[baseFeed]} onLike={onLike} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('liked').textContent).toBe('true'),
+    );
+    expect(screen.getByTestId('count').textContent).toBe('11');
+
+    rerender(
+      <LikeHarness
+        feeds={[{ ...baseFeed, likes: 11, isLiked: true }]}
+        onLike={onLike}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('count').textContent).toBe('11'),
+    );
+
+    rerender(
+      <LikeHarness
+        feeds={[{ ...baseFeed, likes: 12, isLiked: true }]}
+        onLike={onLike}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('count').textContent).toBe('12'),
+    );
+  });
+
+  it('restores the optimistic state from storage across remounts', async () => {
+    const onLike = vi.fn().mockResolvedValue(undefined);
+    const persistKey = 'blog-like-overrides';
+    const { unmount } = render(
+      <LikeHarness
+        feeds={[baseFeed]}
+        onLike={onLike}
+        persistKey={persistKey}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    await waitFor(() => expect(onLike).toHaveBeenCalledWith(baseFeed.id));
+    await waitFor(() =>
+      expect(screen.getByTestId('liked').textContent).toBe('true'),
+    );
+    expect(screen.getByTestId('count').textContent).toBe('11');
+
+    unmount();
+
+    render(
+      <LikeHarness
+        feeds={[baseFeed]}
+        onLike={onLike}
+        persistKey={persistKey}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('liked').textContent).toBe('true'),
+    );
+    expect(screen.getByTestId('count').textContent).toBe('11');
+  });
+});

--- a/libs/ui/src/hooks/useLikeCounts.tsx
+++ b/libs/ui/src/hooks/useLikeCounts.tsx
@@ -23,6 +23,7 @@ interface UseLikeCountsProps {
   onLike?: (id: string) => Promise<any>;
   onUnlike?: (id: string) => Promise<any>;
   persistKey?: string;
+  onError?: (message: string) => void;
 }
 
 const getPersistedLikeCountKey = (persistKey: string) => `${persistKey}:counts`;
@@ -159,6 +160,7 @@ export function useLikeCounts({
   onLike,
   onUnlike,
   persistKey,
+  onError,
 }: UseLikeCountsProps) {
   const [likeCounts, setLikeCounts] = useState<Record<string, number>>({});
   const [hearts, setHearts] = useState<Record<string, boolean>>({});
@@ -327,7 +329,14 @@ export function useLikeCounts({
         delete next[id];
         return next;
       });
-      alert('좋아요 처리에 실패했습니다. 다시 시도해주세요.');
+      const message =
+        error?.message || '좋아요 처리에 실패했습니다. 다시 시도해주세요.';
+
+      if (onError) {
+        onError(message);
+      } else {
+        alert(message);
+      }
     } finally {
       setPendingById((prev) => ({
         ...prev,

--- a/libs/ui/src/hooks/useLikeCounts.tsx
+++ b/libs/ui/src/hooks/useLikeCounts.tsx
@@ -13,6 +13,11 @@ export interface FeedItem {
   isLiked?: boolean;
 }
 
+interface LikeOverride {
+  isLiked: boolean;
+  likeCount: number;
+}
+
 interface UseLikeCountsProps {
   feeds?: FeedItem[];
   onLike?: (id: string) => Promise<any>;
@@ -20,11 +25,24 @@ interface UseLikeCountsProps {
   persistKey?: string;
 }
 
+const getPersistedLikeCountKey = (persistKey: string) => `${persistKey}:counts`;
+
 const getPersistedLikes = (persistKey?: string): Record<string, boolean> => {
   if (!persistKey || typeof window === 'undefined') return {};
 
   try {
     const raw = window.localStorage.getItem(persistKey);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+};
+
+const getPersistedLikeCounts = (persistKey?: string): Record<string, number> => {
+  if (!persistKey || typeof window === 'undefined') return {};
+
+  try {
+    const raw = window.localStorage.getItem(getPersistedLikeCountKey(persistKey));
     return raw ? JSON.parse(raw) : {};
   } catch {
     return {};
@@ -47,6 +65,95 @@ const setPersistedLike = (
   }
 };
 
+const setPersistedLikeCount = (
+  persistKey: string | undefined,
+  id: string,
+  value: number,
+) => {
+  if (!persistKey || typeof window === 'undefined') return;
+
+  try {
+    const prev = getPersistedLikeCounts(persistKey);
+    const next = { ...prev, [id]: value };
+    window.localStorage.setItem(
+      getPersistedLikeCountKey(persistKey),
+      JSON.stringify(next),
+    );
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const clearPersistedLike = (persistKey: string | undefined, id: string) => {
+  if (!persistKey || typeof window === 'undefined') return;
+
+  try {
+    const prev = getPersistedLikes(persistKey);
+    if (!(id in prev)) return;
+    const next = { ...prev };
+    delete next[id];
+    window.localStorage.setItem(persistKey, JSON.stringify(next));
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const clearPersistedLikeCount = (
+  persistKey: string | undefined,
+  id: string,
+) => {
+  if (!persistKey || typeof window === 'undefined') return;
+
+  try {
+    const prev = getPersistedLikeCounts(persistKey);
+    if (!(id in prev)) return;
+    const next = { ...prev };
+    delete next[id];
+    window.localStorage.setItem(
+      getPersistedLikeCountKey(persistKey),
+      JSON.stringify(next),
+    );
+  } catch {
+    // ignore storage failures
+  }
+};
+
+const getPersistedOverride = (
+  feed: FeedItem,
+  persistedLikes: Record<string, boolean>,
+  persistedLikeCounts: Record<string, number>,
+): LikeOverride | undefined => {
+  const hasPersistedLike = Object.prototype.hasOwnProperty.call(
+    persistedLikes,
+    feed.id,
+  );
+  const hasPersistedLikeCount = Object.prototype.hasOwnProperty.call(
+    persistedLikeCounts,
+    feed.id,
+  );
+
+  if (!hasPersistedLike && !hasPersistedLikeCount) {
+    return undefined;
+  }
+
+  const isLiked = hasPersistedLike
+    ? Boolean(persistedLikes[feed.id])
+    : Boolean(feed.isLiked);
+  const likeCount = hasPersistedLikeCount
+    ? persistedLikeCounts[feed.id]
+    : isLiked === Boolean(feed.isLiked)
+      ? feed.likes
+      : isLiked
+        ? feed.likes + 1
+        : Math.max(0, feed.likes - 1);
+
+  if (isLiked === Boolean(feed.isLiked) && likeCount === feed.likes) {
+    return undefined;
+  }
+
+  return { isLiked, likeCount };
+};
+
 export function useLikeCounts({
   feeds,
   onLike,
@@ -56,19 +163,68 @@ export function useLikeCounts({
   const [likeCounts, setLikeCounts] = useState<Record<string, number>>({});
   const [hearts, setHearts] = useState<Record<string, boolean>>({});
   const [pendingById, setPendingById] = useState<Record<string, boolean>>({});
+  const [overridesById, setOverridesById] = useState<
+    Record<string, LikeOverride>
+  >({});
 
   useEffect(() => {
     if (!feeds?.length) return;
+
     const persistedLikes = getPersistedLikes(persistKey);
+    const persistedLikeCounts = getPersistedLikeCounts(persistKey);
+    let nextOverrides = overridesById;
+    let overridesChanged = false;
+
+    for (const feed of feeds) {
+      const override = nextOverrides[feed.id];
+
+      if (
+        override &&
+        override.isLiked === Boolean(feed.isLiked) &&
+        override.likeCount === feed.likes
+      ) {
+        if (!overridesChanged) {
+          nextOverrides = { ...nextOverrides };
+        }
+        delete nextOverrides[feed.id];
+        overridesChanged = true;
+        clearPersistedLike(persistKey, feed.id);
+        clearPersistedLikeCount(persistKey, feed.id);
+        continue;
+      }
+
+      const persistedOverride = getPersistedOverride(
+        feed,
+        persistedLikes,
+        persistedLikeCounts,
+      );
+
+      if (
+        persistedOverride &&
+        persistedOverride.isLiked === Boolean(feed.isLiked) &&
+        persistedOverride.likeCount === feed.likes
+      ) {
+        clearPersistedLike(persistKey, feed.id);
+        clearPersistedLikeCount(persistKey, feed.id);
+      }
+    }
+
+    if (overridesChanged) {
+      setOverridesById(nextOverrides);
+    }
 
     setLikeCounts((prev) => {
       const next = { ...prev };
       let changed = false;
 
       for (const feed of feeds) {
-        if (pendingById[feed.id]) continue;
-        if (next[feed.id] !== feed.likes) {
-          next[feed.id] = feed.likes;
+        const override =
+          nextOverrides[feed.id] ??
+          getPersistedOverride(feed, persistedLikes, persistedLikeCounts);
+        const nextValue = override?.likeCount ?? feed.likes;
+
+        if (next[feed.id] !== nextValue) {
+          next[feed.id] = nextValue;
           changed = true;
         }
       }
@@ -81,8 +237,11 @@ export function useLikeCounts({
       let changed = false;
 
       for (const feed of feeds) {
-        if (pendingById[feed.id]) continue;
-        const nextValue = persistedLikes[feed.id] ?? !!feed.isLiked;
+        const override =
+          nextOverrides[feed.id] ??
+          getPersistedOverride(feed, persistedLikes, persistedLikeCounts);
+        const nextValue = override?.isLiked ?? Boolean(feed.isLiked);
+
         if (next[feed.id] !== nextValue) {
           next[feed.id] = nextValue;
           changed = true;
@@ -91,7 +250,7 @@ export function useLikeCounts({
 
       return changed ? next : prev;
     });
-  }, [feeds, pendingById, persistKey]);
+  }, [feeds, overridesById, persistKey]);
 
   const handleHeartClick = async (
     id: string,
@@ -101,51 +260,59 @@ export function useLikeCounts({
     },
   ) => {
     if (pendingById[id]) return;
-    
+
+    const feed = feeds?.find((item) => item.id === id);
+    const initialIsLiked = feed?.isLiked ?? false;
+    const isCurrentlyLiked = hearts[id] ?? initialIsLiked;
+    const initialCount = feed?.likes ?? 0;
+    const currentCount = likeCounts[id] ?? initialCount;
+    const nextState: LikeOverride = {
+      isLiked: !isCurrentlyLiked,
+      likeCount: isCurrentlyLiked
+        ? Math.max(0, currentCount - 1)
+        : currentCount + 1,
+    };
+
     setPendingById((prev) => ({
       ...prev,
       [id]: true,
     }));
 
-    const feed = feeds?.find((f) => f.id === id);
-    const initialIsLiked = feed?.isLiked ?? false;
-    const isCurrentlyLiked = hearts[id] ?? initialIsLiked;
-    const initialCount = feed?.likes ?? 0;
-    const currentCount = likeCounts[id] ?? initialCount;
+    setOverridesById((prev) => ({
+      ...prev,
+      [id]: nextState,
+    }));
 
-    // Optimistic UI update
     setHearts((prev) => ({
       ...prev,
-      [id]: !isCurrentlyLiked,
+      [id]: nextState.isLiked,
     }));
     setLikeCounts((prev) => ({
       ...prev,
-      [id]: isCurrentlyLiked ? Math.max(0, currentCount - 1) : currentCount + 1,
+      [id]: nextState.likeCount,
     }));
 
-    // API call
     try {
       if (isCurrentlyLiked) {
         const unlikeFn = overrides?.onUnlike || onUnlike || removeBlogLike;
         await unlikeFn(id);
         setPersistedLike(persistKey, id, false);
+        setPersistedLikeCount(persistKey, id, nextState.likeCount);
       } else {
         const likeFn = overrides?.onLike || onLike || addBlogLike;
         await likeFn(id);
         setPersistedLike(persistKey, id, true);
+        setPersistedLikeCount(persistKey, id, nextState.likeCount);
       }
     } catch (error: any) {
       if (error?.errorCode === 'TRIP_CORE_HE_CRS_V003') {
-        setHearts((prev) => ({
-          ...prev,
-          [id]: true,
-        }));
         setPersistedLike(persistKey, id, true);
+        setPersistedLikeCount(persistKey, id, nextState.likeCount);
         return;
       }
 
       console.error('Failed to toggle like:', error);
-      // Revert on failure
+
       setHearts((prev) => ({
         ...prev,
         [id]: isCurrentlyLiked,
@@ -154,6 +321,12 @@ export function useLikeCounts({
         ...prev,
         [id]: currentCount,
       }));
+      setOverridesById((prev) => {
+        if (!(id in prev)) return prev;
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
       alert('좋아요 처리에 실패했습니다. 다시 시도해주세요.');
     } finally {
       setPendingById((prev) => ({

--- a/libs/ui/src/lib/DestinationList.tsx
+++ b/libs/ui/src/lib/DestinationList.tsx
@@ -26,6 +26,7 @@ interface DestinationListProps {
   destinations: Destination[];
   feeds?: FeedItem[];
   onAddLike?: (courseId: string) => void;
+  onLikeError?: (message: string) => void;
   page?: number;
   totalPages?: number;
   onPageChange?: (page: number) => void;
@@ -38,6 +39,7 @@ export function DestinationList({
   destinations,
   feeds,
   onAddLike,
+  onLikeError,
   page = 1,
   totalPages = 0,
   onPageChange,
@@ -74,6 +76,7 @@ export function DestinationList({
     onLike: (id) => addLike(id),
     onUnlike: (id) => removeLike(id),
     persistKey: 'course-like-overrides',
+    onError: onLikeError,
   });
 
   // destinations가 변경될 때 초기화 (MUST be before any early return)

--- a/libs/ui/src/lib/FeedGrid.tsx
+++ b/libs/ui/src/lib/FeedGrid.tsx
@@ -33,7 +33,10 @@ export function FeedGrid({
   compact = false,
 }: FeedGridProps) {
   const navigate = useNavigate();
-  const { likeCounts, hearts, handleHeartClick } = useLikeCounts({ feeds });
+  const { likeCounts, hearts, handleHeartClick } = useLikeCounts({
+    feeds,
+    persistKey: 'blog-like-overrides',
+  });
   const [showComingSoon, setShowComingSoon] = useState(false);
 
   useEffect(() => {

--- a/libs/ui/src/lib/FeedGrid.tsx
+++ b/libs/ui/src/lib/FeedGrid.tsx
@@ -20,6 +20,7 @@ export interface FeedItem {
 export interface FeedGridProps {
   feeds: FeedItem[];
   onFeedLikeChange?: () => void | Promise<void>;
+  onLikeError?: (message: string) => void;
   showMoreButton?: boolean;
   desktopColumns?: 3 | 4;
   compact?: boolean;
@@ -28,6 +29,7 @@ export interface FeedGridProps {
 export function FeedGrid({
   feeds,
   onFeedLikeChange,
+  onLikeError,
   showMoreButton = true,
   desktopColumns = 3,
   compact = false,
@@ -36,6 +38,7 @@ export function FeedGrid({
   const { likeCounts, hearts, handleHeartClick } = useLikeCounts({
     feeds,
     persistKey: 'blog-like-overrides',
+    onError: onLikeError,
   });
   const [showComingSoon, setShowComingSoon] = useState(false);
 

--- a/libs/ui/src/lib/MyPage.tsx
+++ b/libs/ui/src/lib/MyPage.tsx
@@ -41,6 +41,7 @@ interface MyPageProps {
   userName: string;
   user: any;
   onAction: (type: string) => void;
+  onLikeError?: (message: string) => void;
   destinations: Destination[] | Destination[][];
   travelLogs: Destination[] | Destination[][];
   likedRoadmaps: Destination[] | Destination[][];
@@ -58,6 +59,7 @@ export function MyPage({
   userName,
   user,
   onAction,
+  onLikeError,
   destinations,
   travelLogs,
   likedRoadmaps,
@@ -128,6 +130,7 @@ export function MyPage({
   } = useLikeCounts({
     feeds: courseFeeds,
     persistKey: 'course-like-overrides',
+    onError: onLikeError,
   });
   const {
     likeCounts: blogLikeCounts,
@@ -136,6 +139,7 @@ export function MyPage({
   } = useLikeCounts({
     feeds: blogFeeds,
     persistKey: 'blog-like-overrides',
+    onError: onLikeError,
   });
 
   const renderSectionLoading = (message: string) => (


### PR DESCRIPTION
## ���� ���� ����
- ���ƿ� Ŭ�� �� ��Ʈ ���¿� ��ġ�� ���� �ݿ��ǵ��� optimistic update �帧�� �����߽��ϴ�.
- ���� ���� ���Ŀ� stale ���� �����Ͱ� �ٽ� �����͵� ���ƿ� ���°� ���� ������ �ǵ��ư��� �ʵ��� override ����ȭ ������ �߰��߽��ϴ�.
- ���α� ���ƿ� ���� ���� ȸ�� �׽�Ʈ�� �߰��߽��ϴ�.

## ���� ����
- �������� ���ƿ� ��û�� ������ ���� �ݿ��Ǿ ����Ʈ �������� �ʰų� ���� �����ͷ� ���� �����ڰ� "���ƿ䰡 �� ���ȴ�"�� ������ �� �־����ϴ�.
- �̷� ���� �����ڰ� ��Ŭ���ϸ� �̹� ó���� ���¶� ���� ������ alert�� �����Ǿ� UX ȥ���� �߻��߽��ϴ�.

## �ֿ� ���� ����
- before: Ŭ�� ���� ��Ʈ ���� ���� �ٲ�� ���� props�� �ٽ� �������� ���� ������ ������ �� �־����ϴ�.
- after: Ŭ�� ���� ���¸� �ݿ��ϰ�, ���� ���� �����Ͱ� �� ������ ������ ������ ���� override�� �����մϴ�.
- `FeedGrid`���� ���α� ���ƿ� persist key�� ������ remount ���Ŀ��� ���°� �ڿ������� �����ǵ��� �߽��ϴ�.
- �̹� PR���� JS alert�� ���޷� ��ü�ϴ� �۾��� �������� �ʾҽ��ϴ�.

## �׽�Ʈ ����
- `node .\node_modules\vitest\vitest.mjs --config apps/mohang-app/vite.config.mts run apps/mohang-app/src/app/useLikeCounts.spec.tsx`
- ���α�/���� �ε��� ���Ͽ��� ���ƿ並 1ȸ Ŭ������ �� ���� ��Ʈ �� ��ġ�� �ݿ��Ǵ��� Ȯ���մϴ�.
- ���� ���� ��Ȳ������ ���� �ٽ� �������� �ʴ��� Ȯ���մϴ�.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 좋아요 상태와 개수가 로컬에 저장되어 새로고침 후에도 유지됩니다.
  * 좋아요 버튼 클릭 시 즉시 UI가 업데이트됩니다.

* **테스트**
  * 낙관적 UI 동작 및 상태 지속성에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->