### PR TITLE
[FE] 헤더와 마이페이지 프로필 아이콘 제거

### DIFF
--- a/libs/ui/src/lib/Header.tsx
+++ b/libs/ui/src/lib/Header.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 import LogoImage from '../assets/BI.svg';
 import MohangLogo from '../assets/MoHaeng.svg';
-import UserImg from '../assets/userImg.svg';
 import { colors, typography } from '@mohang/ui';
 
 export interface HeaderProps {
@@ -37,7 +36,6 @@ export function Header({ isLoggedIn = false }: HeaderProps) {
               >
                 마이페이지
               </Link>
-              <img src={UserImg} alt="유저 이미지" className="h-6" />
             </>
           ) : (
             <div className="flex gap-2">

--- a/libs/ui/src/lib/MyPage.tsx
+++ b/libs/ui/src/lib/MyPage.tsx
@@ -401,14 +401,7 @@ export function MyPage({
       <h1 className="text-2xl font-bold mb-6">마이페이지</h1>
 
       {/* 프로필 정보 카드 */}
-      <div className="w-full rounded-2xl p-6 flex items-center gap-4 mb-6">
-        <div className="w-16 h-16 bg-gray-200 rounded-full overflow-hidden flex-shrink-0">
-          <div className="w-full h-full bg-[#E5E7EB] flex items-center justify-center text-gray-400">
-            <svg fill="currentColor" viewBox="0 0 24 24" className="w-10 h-10">
-              <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z" />
-            </svg>
-          </div>
-        </div>
+      <div className="w-full rounded-2xl p-6 mb-6">
         <div>
           <h2 className="text-lg font-bold text-gray-800">{userName}</h2>
           <p className="text-sm text-gray-400 font-medium">{user.email}</p>


### PR DESCRIPTION
## 변경 내용 요약
- 공통 헤더에서 로그인 상태 프로필 아이콘을 제거했습니다.
- 마이페이지 상단 프로필 카드에서 사용자 아이콘을 제거했습니다.

## 변경 이유
- 모든 페이지와 마이페이지에서 프로필 사진 아이콘을 노출하지 않도록 UI를 정리하기 위해 변경했습니다.

## 주요 변경 사항
- `libs/ui/src/lib/Header.tsx`에서 `UserImg` import와 아이콘 렌더링을 제거했습니다.
- `libs/ui/src/lib/MyPage.tsx`에서 프로필 카드의 원형 사용자 SVG 블록을 제거하고 이름/이메일 정보만 유지했습니다.

## 테스트 방법
- 로그인 상태로 헤더가 포함된 페이지에 진입해 우측 프로필 아이콘이 보이지 않는지 확인합니다.
- `/mypage`에 진입해 상단 프로필 카드에 원형 사용자 아이콘이 없는지 확인합니다.
- `.\node_modules\.bin\tsc.cmd -p libs\ui\tsconfig.lib.json --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 헤더에서 로그인 사용자의 아바타 이미지를 제거하여 인터페이스를 간결하게 개선했습니다.
  * 프로필 페이지의 프로필 카드 UI를 간소화하여 사용자명과 이메일 정보만 표시되도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->