### PR TITLE
[FE] 로드맵 상세 채팅 진입 및 패널 UI 정리

### DIFF
--- a/apps/mohang-app/src/app/pages/PlanDetailPage/components/PlanInfo.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/components/PlanInfo.tsx
@@ -30,19 +30,19 @@ const PlanInfo: React.FC<PlanInfoProps> = ({
       <div className="flex flex-wrap gap-2.5 items-center">
         <button
           onClick={onBack}
-          className="bg-white px-4 py-2 rounded-full shadow-md text-sm font-bold hover:bg-gray-50 transition-colors flex items-center gap-2"
+          className="inline-flex h-10 items-center gap-2 rounded-full bg-white px-5 text-sm font-bold shadow-md transition-colors hover:bg-gray-50"
         >
           <span className="text-base">←</span>
           <span>뒤로</span>
         </button>
-        <div className="bg-white px-4 py-1.5 rounded-full shadow-md font-bold text-sm text-gray-900 border border-gray-100">
+        <div className="inline-flex h-10 items-center rounded-full border border-gray-100 bg-white px-5 text-sm font-bold text-gray-900 shadow-md">
           {title}
         </div>
-        <div className="bg-white px-4 py-2 rounded-full shadow-md text-gray-600 text-sm font-semibold border border-gray-100">
+        <div className="inline-flex h-10 items-center rounded-full border border-gray-100 bg-white px-5 text-sm font-semibold text-gray-600 shadow-md">
           {dateRange} · {details}
         </div>
         {tasteMatch && (
-          <div className="bg-white px-4 py-2 rounded-full shadow-md text-blue-600 text-sm font-bold border border-gray-100">
+          <div className="inline-flex h-10 items-center rounded-full border border-gray-100 bg-white px-5 text-sm font-bold text-blue-600 shadow-md">
             {tasteMatch}
           </div>
         )}

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/components/ScheduleSidebar.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/components/ScheduleSidebar.tsx
@@ -74,9 +74,6 @@ const ScheduleSidebar: React.FC<ScheduleSidebarProps> = ({
                 >
                   {item.placeCategoryLabel}
                 </span>
-                <span className="text-sky-500 text-[11px] font-black mt-1 uppercase">
-                  {item.time}
-                </span>
                 <p className="text-gray-400 text-[10px] mt-1 font-medium leading-relaxed">
                   {item.location}
                 </p>

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -32,6 +32,9 @@ const apiBaseUrl = import.meta.env.VITE_PROD_BASE_URL || 'https://api.mohaeng.kr
 const defaultCenter = { lat: 16.4855, lng: 97.6216 };
 const defaultAiMessage = '안녕하세요! 어떤 일정 수정을 도와드릴까요?';
 
+const DEFAULT_CHAT_SIDEBAR_WIDTH = 320;
+const DEFAULT_SCHEDULE_SIDEBAR_WIDTH = 320;
+
 interface Message {
   id: string;
   sender: 'user' | 'ai';
@@ -653,6 +656,10 @@ const PlanDetailPage = () => {
     }
   };
 
+  const floatingPanelRightOffset =
+    (isChatSidebarOpen ? DEFAULT_CHAT_SIDEBAR_WIDTH : 0) +
+    (isScheduleSidebarOpen ? DEFAULT_SCHEDULE_SIDEBAR_WIDTH : 0);
+
   return (
     <div className="flex flex-col h-screen overflow-hidden font-sans bg-white text-gray-900">
       {isLoading && (
@@ -717,23 +724,24 @@ const PlanDetailPage = () => {
           }}
         />
 
-        {!isChatSidebarOpen && (
-          <div
-            className={`absolute bottom-32 left-1/2 w-full max-w-[540px] z-10 px-5 animate-in fade-in zoom-in-95 transition-all duration-300 ${
-              isScheduleSidebarOpen ? '-translate-x-2/3' : '-translate-x-1/2'
-            }`}
-          >
-            {hasChatHistory && (
-              <div className="mb-3 flex justify-end">
-                <button
-                  type="button"
-                  onClick={() => setIsChatSidebarOpen(true)}
-                  className="rounded-full bg-white/95 px-4 py-2 text-xs font-bold text-sky-600 shadow-lg transition hover:bg-white"
-                >
-                  채팅 내역 보기
-                </button>
-              </div>
-            )}
+        <div
+          className={`absolute bottom-32 left-0 z-10 flex justify-center px-5 pr-8 transition-[right,opacity,transform] duration-300 ${
+            isChatSidebarOpen
+              ? 'pointer-events-none translate-y-2 opacity-0'
+              : 'translate-y-0 opacity-100'
+          }`}
+          style={{ right: floatingPanelRightOffset }}
+        >
+          <div className="w-full max-w-[540px]">
+            <div className="mb-3 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setIsChatSidebarOpen(true)}
+                className="rounded-full bg-white/95 px-4 py-2 text-xs font-bold text-sky-600 shadow-lg transition hover:bg-white"
+              >
+                {hasChatHistory ? '채팅 내역 보기' : '채팅창 열기'}
+              </button>
+            </div>
             <div className="relative">
               <textarea
                 value={inputValue}
@@ -769,16 +777,11 @@ const PlanDetailPage = () => {
               </button>
             </div>
           </div>
-        )}
+        </div>
 
         <div
-          className={`absolute bottom-8 z-10 w-full flex justify-center px-5 transition-all duration-300 ${
-            !isChatSidebarOpen
-              ? isScheduleSidebarOpen
-                ? 'left-1/2 -translate-x-[56%]'
-                : 'left-1/2 -translate-x-1/2'
-              : '-translate-x-[20%]'
-          }`}
+          className="absolute bottom-8 left-0 z-10 flex justify-center px-5 transition-[right] duration-300"
+          style={{ right: floatingPanelRightOffset }}
         >
           <div className="bg-[#f1f3f5] p-2 rounded-[32px] flex items-center gap-2 shadow-2xl border border-white/50 backdrop-blur-md">
             <button
@@ -850,7 +853,10 @@ const PlanDetailPage = () => {
           suggestions={itineraryData.llmCommentary?.next_action_suggestion || (itineraryData as any).next_action_suggestion}
         />
 
-        <div className={`flex transition-all duration-300 ease-in-out ${isScheduleSidebarOpen ? 'w-[320px]' : 'w-0 overflow-hidden'}`}>
+        <div
+          className="flex overflow-hidden transition-[width] duration-300 ease-in-out"
+          style={{ width: isScheduleSidebarOpen ? DEFAULT_SCHEDULE_SIDEBAR_WIDTH : 0 }}
+        >
           <ScheduleSidebar
             activeDay={activeDay}
             scheduleItems={scheduleData[activeDay] || []}
@@ -880,7 +886,8 @@ const PlanDetailPage = () => {
 
         <button
           onClick={() => setIsScheduleSidebarOpen(!isScheduleSidebarOpen)}
-          className={`absolute top-1/2 -translate-y-1/2 z-30 w-10 h-20 bg-white border-y border-l rounded-l-2xl shadow-[-5px_0_15px_rgba(0,0,0,0.05)] hover:bg-gray-50 flex items-center justify-center transition-all duration-300 ${isScheduleSidebarOpen ? 'right-[320px]' : 'right-0'}`}
+          className="absolute top-1/2 -translate-y-1/2 z-30 h-20 w-10 border-y border-l rounded-l-2xl bg-white shadow-[-5px_0_15px_rgba(0,0,0,0.05)] hover:bg-gray-50 flex items-center justify-center transition-[right] duration-300"
+          style={{ right: isScheduleSidebarOpen ? DEFAULT_SCHEDULE_SIDEBAR_WIDTH : 0 }}
         >
           <div className={`text-gray-400 transform transition-transform duration-300 ${isScheduleSidebarOpen ? 'rotate-180' : ''}`}>
             <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## 변경 내용 요약
- 로드맵 상세에서 첫 메시지 없이도 채팅창을 바로 열 수 있도록 UI를 정리했습니다.
- 채팅 입력창과 Day 네비게이션이 사이드바 열림 상태에 맞춰 자연스럽게 함께 이동하도록 맞췄습니다.
- 일정 사이드바의 시간 표기를 제거하고 상단 정보 pill 높이를 통일했습니다.

## 변경 이유
- 기존에는 사용자가 먼저 채팅을 보내야만 채팅창을 열 수 있어 진입 흐름이 불편했습니다.
- 채팅창과 일정 사이드바를 열 때 하단 UI 위치가 크게 흔들려 보여 시각적으로 불안정했습니다.
- 일정 카드 정보 밀도와 상단 정보 영역 높이를 함께 정리할 필요가 있었습니다.

## 주요 변경 사항
- 이전에는 채팅 이력이 있을 때만 `채팅 내역 보기` 버튼이 노출됐고, 첫 메시지 전에는 채팅 사이드바를 열 수 없었습니다.
- 이제는 채팅 이력이 없어도 `채팅창 열기` 버튼이 항상 보여 즉시 채팅 사이드바를 열 수 있습니다.
- 하단 입력창과 Day 네비게이션은 열린 사이드바 폭만큼 같은 기준으로 이동하도록 조정했습니다.
- 일정 사이드바 카드에서는 시간 문구를 제거해 장소 정보 위주로 노출되도록 정리했습니다.
- 상단의 뒤로 버튼, 제목, 일정 정보 pill 높이를 동일하게 맞췄습니다.

## 테스트 방법
- 로드맵 상세 페이지에 진입합니다.
- 첫 메시지를 보내지 않은 상태에서도 `채팅창 열기` 버튼으로 채팅 사이드바가 열리는지 확인합니다.
- 채팅창과 일정 사이드바를 각각 열고 닫으면서 하단 입력창과 Day 네비게이션이 자연스럽게 함께 이동하는지 확인합니다.
- 일정 사이드바에서 시간 문구가 제거됐는지, 상단 pill 높이가 동일한지 확인합니다.
- `.\node_modules\.bin\tsc.cmd -p apps\mohang-app\tsconfig.app.json --noEmit`를 실행합니다.
  기존 `BlogListPage`, `DiscoverPage`, `HomePage`, `LandingPage`, `MyPage`의 선행 타입 오류로 전체 타입체크는 실패합니다.
