### PR TITLE
[FE] 로드맵 상세 채팅 내역 복원 누락 수정

### DIFF
--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -32,6 +32,7 @@ const apiBaseUrl = import.meta.env.VITE_PROD_BASE_URL || 'https://api.mohaeng.kr
 const defaultCenter = { lat: 16.4855, lng: 97.6216 };
 const defaultAiMessage = '안녕하세요! 어떤 일정 수정을 도와드릴까요?';
 
+const CHAT_STORAGE_KEY_PREFIX = 'plan-detail-chat-history';
 const DEFAULT_CHAT_SIDEBAR_WIDTH = 320;
 const DEFAULT_SCHEDULE_SIDEBAR_WIDTH = 320;
 
@@ -52,6 +53,122 @@ const getDefaultMessages = (): Message[] => [
   },
 ];
 
+const parseChatTimestamp = (timestampValue?: string) => {
+  const parsedTimestamp = timestampValue ? new Date(timestampValue) : new Date();
+  return Number.isNaN(parsedTimestamp.getTime()) ? new Date() : parsedTimestamp;
+};
+
+const getChatStorageKey = (travelCourseId: string) =>
+  `${CHAT_STORAGE_KEY_PREFIX}:${travelCourseId}`;
+
+const readStoredChatMessages = (travelCourseId: string): Message[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(getChatStorageKey(travelCourseId));
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((message: any, index: number) => {
+        const sender =
+          message?.sender === 'user' || message?.sender === 'ai'
+            ? message.sender
+            : null;
+        const text = typeof message?.text === 'string' ? message.text : null;
+
+        if (!sender || !text) {
+          return null;
+        }
+
+        return {
+          id: String(message?.id ?? `stored-${index}`),
+          sender,
+          text,
+          timestamp: parseChatTimestamp(message?.timestamp),
+        };
+      })
+      .filter(Boolean) as Message[];
+  } catch {
+    return [];
+  }
+};
+
+const persistChatMessages = (travelCourseId: string, messages: Message[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const serializableMessages = messages
+    .filter((message) => !message.isPending)
+    .map((message) => ({
+      id: message.id,
+      sender: message.sender,
+      text: message.text,
+      timestamp: message.timestamp.toISOString(),
+    }));
+
+  try {
+    window.localStorage.setItem(
+      getChatStorageKey(travelCourseId),
+      JSON.stringify(serializableMessages),
+    );
+  } catch {}
+};
+
+const isSameChatMessage = (left: Message, right: Message) => {
+  if (left.sender !== right.sender) {
+    return false;
+  }
+
+  if (left.text.trim() !== right.text.trim()) {
+    return false;
+  }
+
+  if (left.sender === 'ai' && left.text.trim() === defaultAiMessage) {
+    return true;
+  }
+
+  return (
+    Math.abs(left.timestamp.getTime() - right.timestamp.getTime()) <
+    10 * 60 * 1000
+  );
+};
+
+const mergeChatMessages = (...messageGroups: Message[][]) => {
+  const merged: Message[] = [];
+  const sortedMessages = messageGroups
+    .flat()
+    .filter((message) => !message.isPending)
+    .sort((left, right) => left.timestamp.getTime() - right.timestamp.getTime());
+
+  sortedMessages.forEach((message) => {
+    const duplicatedMessage = merged.some((existingMessage) =>
+      isSameChatMessage(existingMessage, message),
+    );
+
+    if (!duplicatedMessage) {
+      merged.push(message);
+    }
+  });
+
+  return merged;
+};
+
+const hasMeaningfulChatHistory = (messages: Message[]) =>
+  messages.some(
+    (message) =>
+      message.sender === 'user' || message.text.trim() !== defaultAiMessage,
+  );
+
 const normalizeChatMessage = (message: any, index: number): Message | null => {
   const senderValue = String(message?.sender || message?.role || '').toUpperCase();
   const sender =
@@ -68,15 +185,12 @@ const normalizeChatMessage = (message: any, index: number): Message | null => {
 
   const timestampValue =
     message?.timestamp || message?.createdAt || message?.created_at;
-  const parsedTimestamp = timestampValue ? new Date(timestampValue) : new Date();
 
   return {
     id: String(message?.id ?? `history-${index}`),
     sender,
     text,
-    timestamp: Number.isNaN(parsedTimestamp.getTime())
-      ? new Date()
-      : parsedTimestamp,
+    timestamp: parseChatTimestamp(timestampValue),
   };
 };
 
@@ -98,7 +212,15 @@ const fetchItineraryChatHistory = async (travelCourseId: string) => {
   }
 
   const payload = await response.json();
-  return payload?.data?.chats || payload?.chats || [];
+  return (
+    payload?.data?.chats ||
+    payload?.data?.messages ||
+    payload?.data?.history ||
+    payload?.chats ||
+    payload?.messages ||
+    payload?.history ||
+    []
+  );
 };
 
 const resolveIsMyPlan = ({
@@ -419,7 +541,17 @@ const PlanDetailPage = () => {
       return;
     }
 
+    persistChatMessages(travelCourseId, messages);
+  }, [travelCourseId, messages]);
+
+  useEffect(() => {
+    if (!travelCourseId) {
+      setHasChatHistory(false);
+      return;
+    }
+
     let isCancelled = false;
+    const storedMessages = readStoredChatMessages(travelCourseId);
 
     const fetchChatHistory = async () => {
       try {
@@ -430,13 +562,15 @@ const PlanDetailPage = () => {
           .map((message: any, index: number) => normalizeChatMessage(message, index))
           .filter(Boolean) as Message[];
 
-        setHasChatHistory(normalizedMessages.length > 0);
+        const mergedMessages = mergeChatMessages(
+          storedMessages,
+          normalizedMessages,
+        );
+        const resolvedMessages =
+          mergedMessages.length > 0 ? mergedMessages : getDefaultMessages();
 
-        if (normalizedMessages.length > 0) {
-          setMessages(normalizedMessages);
-        } else {
-          setMessages(getDefaultMessages());
-        }
+        setHasChatHistory(hasMeaningfulChatHistory(mergedMessages));
+        setMessages(resolvedMessages);
       } catch (error: any) {
         if (isCancelled) return;
 
@@ -444,8 +578,10 @@ const PlanDetailPage = () => {
           console.error('Failed to fetch chat history:', error);
         }
 
-        setHasChatHistory(false);
-        setMessages(getDefaultMessages());
+        setHasChatHistory(hasMeaningfulChatHistory(storedMessages));
+        setMessages(
+          storedMessages.length > 0 ? storedMessages : getDefaultMessages(),
+        );
       }
     };
 


### PR DESCRIPTION
## 변경 내용 요약
- 로드맵 상세 채팅 내역을 일정별로 로컬에도 저장하도록 추가했습니다.
- 페이지 재진입 시 서버 채팅 내역과 로컬에 저장된 메시지를 병합해 사용자 메시지까지 함께 복원되도록 수정했습니다.
- 채팅 히스토리 API 응답을 `chats` 외에 `messages`, `history` 형태로도 읽을 수 있게 확장했습니다.

## 변경 이유
- 기존에는 로드맵 상세를 벗어났다가 다시 들어오면 AI 메시지만 남고 사용자가 보낸 채팅은 사라지는 문제가 있었습니다.
- 서버 응답 구조가 달라지거나 사용자 메시지가 서버 히스토리에서 누락되는 경우에도 채팅 흐름이 유지될 필요가 있었습니다.

## 주요 변경 사항
- 일정 `travelCourseId` 기준으로 채팅 메시지를 `localStorage`에 저장하도록 추가했습니다.
- 페이지 진입 시 저장된 로컬 메시지와 서버 히스토리를 시간순으로 병합하고, 기본 안내 문구 중복은 제거하도록 처리했습니다.
- 서버 히스토리 요청 실패 시에도 로컬에 남아 있는 채팅 내역이 있으면 그대로 복원하도록 바꿨습니다.

## 테스트 방법
- 로드맵 상세 페이지에서 사용자 메시지를 1개 이상 보냅니다.
- 다른 페이지로 이동한 뒤 같은 로드맵 상세로 다시 진입합니다.
- AI 메시지뿐 아니라 사용자가 보낸 메시지도 함께 복원되는지 확인합니다.
- `.\node_modules\.bin\tsc.cmd -p apps\mohang-app\tsconfig.app.json --noEmit`를 실행합니다.
  기존 `BlogListPage`, `DiscoverPage`, `HomePage`, `LandingPage`, `MyPage`의 선행 타입 오류로 전체 타입체크는 실패합니다.
