### PR TITLE
[FE] 토큰 만료 시 로그인 화면 강제 이동 처리

### DIFF
--- a/apps/mohang-app/src/app/components/AuthGuard.tsx
+++ b/apps/mohang-app/src/app/components/AuthGuard.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import {
   getAccessToken,
-  getRefreshToken,
-  refreshToken,
   clearTokens,
   LoadingScreen,
 } from '@mohang/ui';
@@ -18,42 +15,23 @@ const AuthGuard: React.FC<AuthGuardProps> = ({ children }) => {
   const [isAuthChecking, setIsAuthChecking] = useState(
     !initialToken || initialToken === 'undefined',
   );
-  const [loadingMessage, setLoadingMessage] =
-    useState('로그인 정보를 확인하고 있습니다');
-  const navigate = useNavigate();
 
   useEffect(() => {
-    const checkAuth = async () => {
-      const token = getAccessToken();
-      const refresh = getRefreshToken();
+    const token = getAccessToken();
 
-      if (token && token !== 'undefined') {
-        setIsAuthChecking(false);
-        return;
-      }
+    if (token && token !== 'undefined') {
+      setIsAuthChecking(false);
+      return;
+    }
 
-      if (refresh && refresh !== 'undefined') {
-        try {
-          setLoadingMessage('로그인 세션을 복구하고 있습니다');
-          await refreshToken(refresh);
-          setIsAuthChecking(false);
-          return;
-        } catch (error) {
-          console.error('[AuthGuard] Token refresh failed:', error);
-        }
-      }
-
-      clearTokens();
-      navigate('/login', { replace: true });
-    };
-
-    checkAuth();
-  }, [navigate]);
+    clearTokens();
+    window.location.replace('/login');
+  }, []);
 
   if (isAuthChecking) {
     return (
       <LoadingScreen
-        message={loadingMessage}
+        message="로그인 정보를 확인하고 있습니다"
         description="잠시만 기다려주세요"
       />
     );

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -13,6 +13,7 @@ import {
   chatItineraryEdit,
   chatItineraryEditStatus,
   getAccessToken,
+  clearTokens,
   LoadingScreen,
   getCourseDetail,
   getMainPageUser,
@@ -205,6 +206,12 @@ const fetchItineraryChatHistory = async (travelCourseId: string) => {
 
   if (response.status === 404) {
     return [];
+  }
+
+  if (response.status === 401) {
+    clearTokens();
+    window.location.replace('/login');
+    throw new Error('로그인 세션이 만료되었습니다.');
   }
 
   if (!response.ok) {

--- a/libs/ui/src/api/authUtils.ts
+++ b/libs/ui/src/api/authUtils.ts
@@ -2,6 +2,9 @@ import Cookies from 'js-cookie';
 
 const ACCESS_TOKEN_KEY = 'accessToken';
 const REFRESH_TOKEN_KEY = 'refreshToken';
+const LOGIN_PATH = '/login';
+
+let isSessionExpiryRedirecting = false;
 
 /**
  * Access Token 저장 (기본 1시간)
@@ -52,6 +55,24 @@ export const getRefreshToken = () => {
 export const clearTokens = () => {
   Cookies.remove(ACCESS_TOKEN_KEY);
   Cookies.remove(REFRESH_TOKEN_KEY);
+};
+
+export const redirectToLoginOnSessionExpired = () => {
+  if (typeof window === 'undefined' || isSessionExpiryRedirecting) {
+    return;
+  }
+
+  isSessionExpiryRedirecting = true;
+  clearTokens();
+
+  if (window.location.pathname !== LOGIN_PATH) {
+    window.location.replace(LOGIN_PATH);
+    return;
+  }
+
+  setTimeout(() => {
+    isSessionExpiryRedirecting = false;
+  }, 0);
 };
 
 /**

--- a/libs/ui/src/api/client.ts
+++ b/libs/ui/src/api/client.ts
@@ -8,7 +8,7 @@ import axios, {
   AxiosInstance,
   InternalAxiosRequestConfig,
 } from 'axios';
-import { getAccessToken, getRefreshToken, clearTokens } from './authUtils';
+import { getAccessToken, redirectToLoginOnSessionExpired } from './authUtils';
 
 const BASE_URL = import.meta.env.VITE_PROD_BASE_URL || 'https://api.mohaeng.kr';
 
@@ -34,6 +34,28 @@ export const privateApi: AxiosInstance = axios.create({
   },
 });
 
+const hasAuthorizationHeader = (
+  config?: InternalAxiosRequestConfig,
+): boolean => {
+  const authorization =
+    config?.headers?.Authorization ?? config?.headers?.authorization;
+
+  return typeof authorization === 'string' && authorization.trim() !== '';
+};
+
+publicApi.interceptors.response.use(
+  (response) => response,
+  (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig | undefined;
+
+    if (error.response?.status === 401 && hasAuthorizationHeader(originalRequest)) {
+      redirectToLoginOnSessionExpired();
+    }
+
+    return Promise.reject(error);
+  },
+);
+
 // Private API Request Interceptor - Access Token 자동 추가
 privateApi.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
@@ -48,40 +70,12 @@ privateApi.interceptors.request.use(
   },
 );
 
-// Private API Response Interceptor - 401 에러 처리 (토큰 갱신 등)
+// Private API Response Interceptor - 401 에러 처리
 privateApi.interceptors.response.use(
   (response) => response,
-  async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & {
-      _retry?: boolean;
-    };
-
-    // 401 에러이고 재시도하지 않은 경우
-    if (error.response?.status === 401 && !originalRequest._retry) {
-      originalRequest._retry = true;
-
-      try {
-        const refreshToken = getRefreshToken();
-        if (!refreshToken) {
-          throw new Error('No refresh token');
-        }
-
-        // 토큰 갱신 API 호출 (추후 구현)
-        // const response = await publicApi.post('/api/v1/auth/refresh', { refreshToken });
-        // const { accessToken } = response.data;
-        // setAccessToken(accessToken);
-
-        // 재시도
-        // return privateApi(originalRequest);
-      } catch (refreshError) {
-        // 토큰 갱신 실패 - 로그아웃 처리
-        clearTokens();
-        // 3초 대기 후 리다이렉트 (사용자 경험 통일)
-        setTimeout(() => {
-          window.location.href = '/login';
-        }, 3000);
-        return Promise.reject(refreshError);
-      }
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      redirectToLoginOnSessionExpired();
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
﻿## 변경 내용 요약
- 인증이 필요한 API 요청이 401을 반환하면 토큰을 정리하고 즉시 `/login`으로 이동하도록 공통 처리 로직을 추가했습니다.
- `AuthGuard`에서 access token이 없을 때 refresh 복구를 시도하지 않고 바로 로그인 화면으로 이동하도록 단순화했습니다.
- `PlanDetailPage`의 수동 `fetch` 요청도 401 응답 시 동일하게 로그인 화면으로 이동하도록 맞췄습니다.

## 변경 이유
- 토큰 세션이 만료돼도 일부 화면에서는 로그인 페이지로 강제 이동하지 않거나, 진입 시 복구 흐름과 요청 실패 흐름이 제각각이었습니다.
- 인증 만료 동작을 한 방향으로 통일해야 사용자 흐름이 예측 가능해집니다.

## 주요 변경 사항
- 이전에는 `privateApi` 401 응답에서 refresh token 유무를 보고 복구를 시도하거나 지연 후 이동했지만, 이제는 인증 만료로 판단되면 즉시 토큰을 삭제하고 로그인 화면으로 보냅니다.
- 보호 라우트 진입 시 access token이 없으면 더 이상 세션 복구를 시도하지 않고 바로 로그인 화면으로 이동합니다.
- `PlanDetailPage`의 채팅 내역 조회처럼 axios를 거치지 않는 수동 요청도 401이면 같은 방식으로 처리됩니다.
- 현재 PR은 `fix/304-home-preference-results` 위에 쌓는 stacked PR입니다.

## 테스트 방법
- 로그인 후 access token이 만료된 상태에서 인증이 필요한 화면이나 API 요청을 발생시켜 `/login`으로 즉시 이동하는지 확인합니다.
- 로드맵 상세 페이지에서 채팅 내역 조회 요청이 401일 때도 동일하게 로그인 화면으로 이동하는지 확인합니다.
- `./node_modules/.bin/tsc.cmd -p apps/mohang-app/tsconfig.app.json --noEmit`
  - 기존 `BlogListPage`, `DiscoverPage`, `HomePage`, `LandingPage`, `MyPage` 타입 오류로 실패
