### PR TITLE
[FE] 로드맵 수정 요청 중복 전송 및 연속 요청 처리 수정

### DIFF
--- a/apps/mohang-app/src/app/pages/PlanDetailPage/components/ChatSidebar.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/components/ChatSidebar.tsx
@@ -16,6 +16,13 @@ interface ChatSidebarProps {
   inputValue: string;
   onInputChange: (value: string) => void;
   onSendMessage: (customMessage?: string) => void;
+  onInputKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onInputCompositionStart: (
+    event: React.CompositionEvent<HTMLInputElement>,
+  ) => void;
+  onInputCompositionEnd: (
+    event: React.CompositionEvent<HTMLInputElement>,
+  ) => void;
   messages: Message[];
   isTyping?: boolean;
   suggestions?: string[];
@@ -27,6 +34,9 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
   inputValue,
   onInputChange,
   onSendMessage,
+  onInputKeyDown,
+  onInputCompositionStart,
+  onInputCompositionEnd,
   messages,
   isTyping,
   suggestions,
@@ -160,6 +170,8 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
             {suggestions.map((s, i) => (
               <button
                 key={i}
+                type="button"
+                disabled={isTyping}
                 onClick={() => onSendMessage(s)}
                 className="bg-white border border-sky-200 text-sky-600 px-3 py-1.5 rounded-full text-[10px] font-bold hover:bg-sky-50 transition-colors shadow-sm"
               >
@@ -179,9 +191,13 @@ const ChatSidebar: React.FC<ChatSidebarProps> = ({
             className="w-full bg-gray-50 px-5 py-3 pr-12 rounded-xl text-[11px] outline-none border border-transparent focus:border-sky-300 focus:bg-white transition-all shadow-lg"
             value={inputValue}
             onChange={(e) => onInputChange(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && onSendMessage()}
+            onCompositionStart={onInputCompositionStart}
+            onCompositionEnd={onInputCompositionEnd}
+            onKeyDown={onInputKeyDown}
           />
           <button
+            type="button"
+            disabled={isTyping || inputValue.trim().length === 0}
             onClick={() => onSendMessage()}
             className="absolute right-3 top-1/2 -translate-y-1/2 bg-sky-500 text-white p-1.5 rounded-lg hover:bg-sky-600 transition-all active:scale-90"
           >

--- a/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
+++ b/apps/mohang-app/src/app/pages/PlanDetailPage/index.tsx
@@ -1,4 +1,11 @@
-import { useState, useMemo, useEffect } from 'react';
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  type CompositionEvent,
+  type KeyboardEvent,
+} from 'react';
 import { useAlert } from '../../context/AlertContext';
 import { useJsApiLoader } from '@react-google-maps/api';
 import MapSection from './components/MapSection';
@@ -321,6 +328,7 @@ const PlanDetailPage = () => {
   const [hasChatHistory, setHasChatHistory] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [currentUser, setCurrentUser] = useState<UserResponse | null>(null);
+  const isMessageComposingRef = useRef(false);
 
   useEffect(() => {
     const token = getAccessToken();
@@ -599,9 +607,41 @@ const PlanDetailPage = () => {
     };
   }, [travelCourseId]);
 
+  const handleMessageCompositionStart = (
+    _event?: CompositionEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => {
+    isMessageComposingRef.current = true;
+  };
+
+  const handleMessageCompositionEnd = (
+    _event?: CompositionEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => {
+    isMessageComposingRef.current = false;
+  };
+
+  const handleMessageInputKeyDown = (
+    event: KeyboardEvent<HTMLTextAreaElement | HTMLInputElement>,
+  ) => {
+    if (event.key !== 'Enter') {
+      return;
+    }
+
+    if (
+      event.shiftKey ||
+      event.nativeEvent.isComposing ||
+      isMessageComposingRef.current ||
+      event.keyCode === 229
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    void handleSendMessage();
+  };
+
   const handleSendMessage = async (customMessage?: string) => {
-    const textToSend = customMessage || inputValue;
-    if (!textToSend.trim()) return;
+    const textToSend = (customMessage ?? inputValue).trim();
+    if (!textToSend || isTyping || isMessageComposingRef.current) return;
     if (!travelCourseId) {
       showAlert('일정 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.', 'info');
       return;
@@ -632,17 +672,41 @@ const PlanDetailPage = () => {
     setMessages((prev) => [...prev, pendingMessage]);
 
     try {
-      const responseRes = (await chatItineraryEdit(travelCourseId, originalInput)) as any;
-      const response = responseRes.data.chat || responseRes;
+      const responseRes = (await chatItineraryEdit(
+        travelCourseId,
+        originalInput,
+      )) as any;
+      const response =
+        responseRes?.data?.chat || responseRes?.data || responseRes;
+      const responseJobId = response?.jobId;
+
+      if (!responseJobId) {
+        throw new Error('Failed to start itinerary edit job.');
+      }
       
       let lastStatusMessage = '';
       const pollInterval = setInterval(async () => {
         try {
-          const statusRes = (await chatItineraryEditStatus(response.jobId)) as any;
+          const statusRes = (await chatItineraryEditStatus(responseJobId)) as any;
           const statusData = statusRes.data || statusRes;
-          const status = statusData.status || statusData;
-
-          const currentMessage = status.message;
+          const resolvedStatus =
+            statusData?.status ||
+            statusData?.data?.status ||
+            statusData?.result?.status ||
+            statusData;
+          const currentMessage =
+            statusData?.message ||
+            statusData?.data?.message ||
+            statusData?.result?.message ||
+            '';
+          const updatedTravelCourseId =
+            statusData?.travelCourseId ||
+            statusData?.data?.travelCourseId ||
+            statusData?.result?.travelCourseId ||
+            statusData?.courseId ||
+            statusData?.data?.courseId ||
+            statusData?.result?.courseId ||
+            null;
           if (currentMessage && currentMessage !== lastStatusMessage && currentMessage !== '...') {
             lastStatusMessage = currentMessage;
             setMessages((prev) => [
@@ -656,27 +720,28 @@ const PlanDetailPage = () => {
             ]);
           }
 
-          if (status.status === 'COMPLETED' || status.status === 'SUCCESS' || status === 'COMPLETED' || status === 'SUCCESS') {
+          if (resolvedStatus === 'COMPLETED' || resolvedStatus === 'SUCCESS') {
             clearInterval(pollInterval);
             setIsTyping(false);
 
             try {
-              const res = (await getItineraryResult(response.jobId)) as any;
-              const resultData = res.data || res;
-              const data = resultData.result?.data || resultData.data || resultData;
-              const editedCourseId =
-                resultData.result?.travelCourseId ||
-                resultData.travelCourseId ||
-                resultData.data?.travelCourseId ||
-                data?.travelCourseId ||
-                data?.id;
+              let data: any = null;
+              const editedCourseId = updatedTravelCourseId || travelCourseId;
+
+              if (editedCourseId) {
+                const courseDetailRes = await getCourseDetail(editedCourseId);
+                data = courseDetailRes.data;
+                setTravelCourseId(editedCourseId);
+              } else {
+                const res = (await getItineraryResult(responseJobId)) as any;
+                const resultData = res.data || res;
+                data = resultData.result?.data || resultData.data || resultData;
+              }
+
               const authorName =
                 data?.userName || data?.authorName || data?.author_name;
 
               if (data && data.itinerary) {
-                if (editedCourseId) {
-                  setTravelCourseId(editedCourseId);
-                }
                 setItineraryData({
                   itinerary: data.itinerary,
                   title: data.title || '나의 여행 일정',
@@ -719,10 +784,11 @@ const PlanDetailPage = () => {
                 },
               ];
             });
-          } else if (status === 'FAILED' || status.status === 'FAILED') {
+          } else if (resolvedStatus === 'FAILED') {
             clearInterval(pollInterval);
             setIsTyping(false);
-            const failMsg = status.message || '죄송합니다. 일정 수정에 실패했습니다.';
+            const failMsg =
+              currentMessage || '죄송합니다. 일정 수정에 실패했습니다.';
             setMessages((prev) => [
               ...prev.filter((m) => m.id !== pendingMsgId),
               {
@@ -889,18 +955,17 @@ const PlanDetailPage = () => {
               <textarea
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    handleSendMessage();
-                  }
-                }}
+                onCompositionStart={handleMessageCompositionStart}
+                onCompositionEnd={handleMessageCompositionEnd}
+                onKeyDown={handleMessageInputKeyDown}
                 placeholder="원하는 일정 수정 내용을 입력해주세요."
                 rows={1}
                 className="scrollbar-hide min-h-[56px] max-h-40 w-full resize-none overflow-y-auto rounded-2xl border-none bg-white px-6 py-[15px] pr-16 text-[15px] leading-6 shadow-2xl outline-none transition-all focus:ring-2 focus:ring-sky-400"
               />
               <button
-                onClick={() => handleSendMessage()}
+                type="button"
+                disabled={isTyping || inputValue.trim().length === 0}
+                onClick={() => void handleSendMessage()}
                 className="absolute right-5 top-1/2 -translate-y-1/2 text-sky-400"
               >
                 <svg
@@ -991,6 +1056,9 @@ const PlanDetailPage = () => {
           inputValue={inputValue}
           onInputChange={setInputValue}
           onSendMessage={handleSendMessage}
+          onInputKeyDown={handleMessageInputKeyDown}
+          onInputCompositionStart={handleMessageCompositionStart}
+          onInputCompositionEnd={handleMessageCompositionEnd}
           messages={messages}
           isTyping={isTyping}
           suggestions={itineraryData.llmCommentary?.next_action_suggestion || (itineraryData as any).next_action_suggestion}


### PR DESCRIPTION
﻿## 변경 내용 요약
- 로드맵 상세 채팅 입력에 조합형 입력(IME) 상태를 반영해 마지막 글자 입력 시 중복 전송되지 않도록 수정했습니다.
- 전송 중에는 같은 요청이 다시 나가지 않도록 입력/버튼/추천 버튼 재진입을 막았습니다.
- 수정 job 완료 후 status 응답의 최신 `travelCourseId`를 우선 반영하고, 최신 코스 상세를 다시 조회해 다음 수정 요청도 계속 이어지도록 정리했습니다.

## 변경 이유
- 한글 입력 후 Enter 전송 시 마지막 글자 조합과 전송 이벤트가 겹쳐 동일 요청이 두 번 들어가는 문제가 있었습니다.
- 프론트가 수정 완료 후 최신 코스를 안정적으로 이어받지 못해 여러 번 수정 요청을 반복하면 흐름이 끊길 수 있었습니다.

## 주요 변경 사항
- `PlanDetailPage/index.tsx`에 입력 조합 상태 추적과 공통 Enter 처리 핸들러를 추가했습니다.
- 채팅 전송 중에는 textarea, 사이드바 input, 제안 버튼, 전송 버튼에서 중복 호출이 나가지 않게 막았습니다.
- 수정 완료 시 `chatItineraryEditStatus`에서 최신 `travelCourseId`를 우선 읽고, 가능하면 `getCourseDetail`로 최신 코스를 다시 불러와 다음 요청도 최신 코스를 기준으로 보내게 했습니다.
- 현재 PR은 `fix/306-force-login-on-session-expiry` 위에 쌓는 stacked PR입니다.

## 테스트 방법
- 한글 입력기로 로드맵 수정 요청을 입력한 뒤 Enter를 눌렀을 때 마지막 글자가 중복 전송되지 않는지 확인합니다.
- 전송 중에 Enter, 전송 버튼, 추천 버튼을 연속으로 눌러도 요청이 한 번만 나가는지 확인합니다.
- 수정 요청을 여러 번 반복해도 다음 요청이 계속 정상적으로 전송되는지 확인합니다.
- `./node_modules/.bin/tsc.cmd -p apps/mohang-app/tsconfig.app.json --noEmit`
  - 기존 `BlogListPage`, `DiscoverPage`, `HomePage`, `LandingPage`, `MyPage` 타입 오류로 실패
