### PR TITLE
[FE] 홈 운영 종료 안내 팝업 추가

### DIFF
--- a/apps/mohang-app/src/app/components/ServiceEndNoticeModal.tsx
+++ b/apps/mohang-app/src/app/components/ServiceEndNoticeModal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react';
+import noticeImage from '../../assets/images/mohaeng-logo.svg';
+
+const NOTICE_SUPPRESS_UNTIL_KEY = 'mohaeng-service-end-notice-suppress-until';
+const NOTICE_END_AT = new Date('2026-05-12T23:59:00+09:00').getTime();
+
+const isNoticeSuppressed = () => {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  const storedUntil = window.localStorage.getItem(NOTICE_SUPPRESS_UNTIL_KEY);
+
+  if (!storedUntil) {
+    return false;
+  }
+
+  const suppressUntil = Number(storedUntil);
+
+  if (Number.isNaN(suppressUntil) || Date.now() >= suppressUntil) {
+    window.localStorage.removeItem(NOTICE_SUPPRESS_UNTIL_KEY);
+    return false;
+  }
+
+  return true;
+};
+
+const getTomorrowStart = () => {
+  const tomorrowStart = new Date();
+  tomorrowStart.setHours(24, 0, 0, 0);
+  return tomorrowStart.getTime();
+};
+
+export default function ServiceEndNoticeModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hideForToday, setHideForToday] = useState(false);
+
+  useEffect(() => {
+    if (Date.now() > NOTICE_END_AT || isNoticeSuppressed()) {
+      return;
+    }
+
+    setIsOpen(true);
+  }, []);
+
+  const handleClose = () => {
+    if (typeof window !== 'undefined') {
+      if (hideForToday) {
+        window.localStorage.setItem(
+          NOTICE_SUPPRESS_UNTIL_KEY,
+          String(getTomorrowStart()),
+        );
+      } else {
+        window.localStorage.removeItem(NOTICE_SUPPRESS_UNTIL_KEY);
+      }
+    }
+
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        handleClose();
+      }
+    };
+
+    document.body.style.overflow = 'hidden';
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, hideForToday]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/55 px-4 py-6">
+      <div className="absolute inset-0" onClick={handleClose} aria-hidden="true" />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="service-end-notice-message"
+        className="relative w-full max-w-[440px] overflow-hidden rounded-[22px] border border-slate-200 bg-white shadow-[0_32px_90px_rgba(15,23,42,0.28)]"
+      >
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-3">
+          <strong className="truncate pr-4 text-[17px] font-extrabold text-slate-800">
+            모행 서비스 운영 안내
+          </strong>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="운영 안내 팝업 닫기"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 pb-6 pt-5">
+          <div className="rounded-[20px] bg-white px-8 py-8">
+            <img
+              src={noticeImage}
+              alt=""
+              className="mx-auto w-full max-w-[210px]"
+            />
+          </div>
+
+          <p
+            id="service-end-notice-message"
+            className="mt-6 text-center text-[16px] font-semibold leading-8 text-slate-700 break-keep"
+          >
+            <span className="block">모행(Mohaeng) 서비스는 다음주 화요일</span>
+            <span className="block">(2026.05.12. 23시 59분)까지 운영될 예정입니다.</span>
+            <span className="block">많은 사랑 감사합니다❤️</span>
+          </p>
+
+          <label className="mt-5 ml-1 inline-flex cursor-pointer items-end gap-2.5 text-[14px] font-medium text-slate-500">
+            <input
+              type="checkbox"
+              checked={hideForToday}
+              onChange={(event) => setHideForToday(event.target.checked)}
+              className="mt-0 h-4 w-4 shrink-0 rounded border-slate-300 text-sky-500 align-middle focus:ring-sky-400"
+            />
+            <span className="leading-none">오늘 하루 보지 않기</span>
+          </label>
+
+          <button
+            type="button"
+            onClick={handleClose}
+            className="w-full rounded-full bg-[#00C2FF] px-5 py-3 text-sm font-bold text-white transition hover:brightness-95"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mohang-app/src/app/pages/HomePage.tsx
+++ b/apps/mohang-app/src/app/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { colors, typography } from '@mohang/ui';
 import { useAlert } from '../context/AlertContext';
+import ServiceEndNoticeModal from '../components/ServiceEndNoticeModal';
 import {
   Header,
   TravelCard,
@@ -825,6 +826,7 @@ export function HomePage({ initialUser }: HomePageProps) {
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <ServiceEndNoticeModal />
       <Header isLoggedIn={isLoggedIn} />
 
       <main style={{ zoom: '0.85' }}>


### PR DESCRIPTION
## 변경 내용 요약
- 홈 화면에 서비스 운영 종료 안내 팝업을 추가했습니다.
- 팝업에서 운영 종료 문구와 이미지를 표시하고, `오늘 하루 보지 않기` 옵션을 제공합니다.
- 팝업은 홈페이지에서만 노출되며, 체크 없이 닫으면 재방문 시 다시 표시됩니다.

## 변경 이유
- 서비스 운영 종료 시점을 홈 화면에서 명확하게 안내해야 했습니다.
- 사용자가 같은 날 반복 노출을 제어할 수 있도록 하루 숨김 동작이 필요했습니다.

## 주요 변경 사항
- `HomePage`에 운영 안내 팝업을 연결했습니다.
- `ServiceEndNoticeModal` 공용 컴포넌트를 추가해 팝업 UI와 닫기/하루 숨김 로직을 구현했습니다.
- 팝업은 `localStorage`를 사용해 다음 자정 전까지 숨김 상태를 유지합니다.

## 테스트 방법
- 홈 화면(`/home`) 진입 시 팝업이 노출되는지 확인합니다.
- `오늘 하루 보지 않기`를 체크하지 않고 닫은 뒤 홈으로 다시 오면 팝업이 다시 뜨는지 확인합니다.
- `오늘 하루 보지 않기`를 체크하고 닫은 뒤 같은 날 홈으로 다시 오면 팝업이 뜨지 않는지 확인합니다.
- `vite build --config apps/mohang-app/vite.config.mts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서비스 종료 알림 모달이 추가되었습니다. 사용자는 모달을 닫거나 "오늘 하루 보지 않기" 옵션을 통해 다음 날까지 알림 재표시를 방지할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->